### PR TITLE
use the host sanitization provided by webserve.saveSearch() to ensure th...

### DIFF
--- a/sickbeard/utorrent.py
+++ b/sickbeard/utorrent.py
@@ -28,10 +28,7 @@ from sickbeard.exceptions import ex
 
 def sendTORRENT(result):
 
-    host = sickbeard.TORRENT_HOST
-    if not host.endswith("/"):
-        host = host + "/"
-    host = host+'gui/'
+    host = sickbeard.TORRENT_HOST+'gui/'
     
     username = sickbeard.TORRENT_USERNAME
     password = sickbeard.TORRENT_PASSWORD

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -791,6 +791,8 @@ class ConfigSearch:
         sab_host = re.sub(regex, regex_sub, postData.get('sab_host', ''))
         sickbeard.SAB_HOST = sab_host
 
+        sickbeard.TORRENT_HOST = re.sub(regex, regex_sub, postData.get('torrent_host', ''))
+
         sickbeard.save_config()
 
         if len(results) > 0:


### PR DESCRIPTION
saveSearch will always ensure a trailing / for any host if you sanitize it with the provided regex
