### PR TITLE
Fixed an issue where series with airing year in the filename were unable to be post processed

### DIFF
--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -100,6 +100,9 @@ def sceneToNormalShowNames(name):
         # add brackets around the country
         country_match_str = '|'.join(countryList.values())
         results.append(re.sub('(?i)([. _-])('+country_match_str+')$', '\\1(\\2)', cur_name))
+        
+        # remove the year
+        results.append(re.sub('(\D)(\d{4})$', '', cur_name))
 
     results += name_list
 


### PR DESCRIPTION
Fixed an issue where series with airing year in the filename were unable to be post processed. The solution is to generate candidate names with years and without them.

For example, the problem can be seen with Hawaii Five-0. Scene file naming convention uses "Hawaii.Five-0.2010" as the series name, but in the databases it is known as "Hawaii Five-0". When the list of candidate names for DB lookup were generated sickbeard only created "Hawaii Five-0 2010" and "Hawaii Five-0 (2010)". With this fix it will generate a thrid candida name "Hawaii Five-0" by removing the year.
