### PR TITLE
Fixes for saving configuration from "Start torrent paused" checkbox and default parent folder

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -632,6 +632,7 @@ class ConfigGeneral:
     @cherrypy.expose
     def saveRootDirs(self, rootDirString=None):
         sickbeard.ROOT_DIRS = rootDirString
+        sickbeard.save_config()
 
     @cherrypy.expose
     def saveAddShowDefaults(self, defaultFlattenFolders, defaultStatus, anyQualities, bestQualities):


### PR DESCRIPTION
The configuration set in the UI wasn't being propagated to the configuration file for the "Start torrent paused" checkbox. The same issue appeared when trying to set a parent folder as default. Pretty simple fixes.
