### PR TITLE
Fixed XML encoding for title and url

### DIFF
--- a/sickbeard/providers/sceneaccess.py
+++ b/sickbeard/providers/sceneaccess.py
@@ -27,6 +27,7 @@ import exceptions
 import sickbeard
 import generic
 
+from xml.sax.saxutils import escape
 from sickbeard.common import Quality
 from sickbeard import logger
 from sickbeard import tvcache
@@ -247,7 +248,7 @@ class SceneAccessCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
             for title, url in data:
-                xml += "<item>" + "<title>" + title + "</title>" +  "<link>"+ url + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml
         

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -27,6 +27,7 @@ import exceptions
 import sickbeard
 import generic
 
+from xml.sax.saxutils import escape
 from sickbeard.common import Quality
 from sickbeard import logger
 from sickbeard import tvcache
@@ -249,7 +250,7 @@ class TorrentLeechCache(tvcache.TVCache):
                 "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
         
         for title, url in data:
-            xml += "<item>" + "<title>" + title + "</title>" +  "<link>"+ url + "</link>" + "</item>"
+        	xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
         xml += "</channel> </rss>"
         return xml
     


### PR DESCRIPTION
This is my second pull request so please bear with me. 

An `&' in the title and/or URL of a show, for example "Ben 10 Original & Alien Force & Ultimate Alien & Omniverse Complete", will create an invalid XML file that will result in an error:

Error:
        SEARCHQUEUE-RSS-SEARCH :: Error trying to load TorrentLeech RSS feed: not well-formed (invalid token): line 1, column 10544

Invalid XML:

```
    <item>
    <title>Ben 10 Original & Alien Force & Ultimate Alien & Omniverse Complete</title>
    <link>http://www.torrentleech.org/download/Ben.10.Original.&.Alien.Force.&.Ultimate.Alien.&.Omniverse.Complete.torrent</link>
    </item>
```

I've added XML escaping for the Title and URL encoding for the URL:

```
    <item>
    <title>Ben 10 Original &amp; Alien Force &amp; Ultimate Alien &amp; Omniverse Complete</title>
    <link>http://www.torrentleech.org/download/Ben.10.Original.%26.Alien.Force.%26.Ultimate.Alien.%26.Omniverse.Complete.torrent</link>
    </item>
```

I've also applied this on sceneaccess since it uses the same mechanism
