### PR TITLE
Improved most providers to use all search patterns defined in sickbeard....

### DIFF
--- a/sickbeard/providers/bithdtv.py
+++ b/sickbeard/providers/bithdtv.py
@@ -101,8 +101,9 @@ class BITHDTVProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                   
         return search_string
 
     ###################################################################################################
@@ -118,9 +119,10 @@ class BITHDTVProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -100,8 +100,9 @@ class BTDIGGProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         return search_string
 
     ###################################################################################################
@@ -117,9 +118,10 @@ class BTDIGGProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################

--- a/sickbeard/providers/fucklimits.py
+++ b/sickbeard/providers/fucklimits.py
@@ -100,8 +100,9 @@ class FUCKLIMITSProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         return search_string
 
     ###################################################################################################
@@ -117,9 +118,10 @@ class FUCKLIMITSProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -101,8 +101,9 @@ class IPTorrentsProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         return search_string
 
     ###################################################################################################
@@ -118,9 +119,10 @@ class IPTorrentsProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################

--- a/sickbeard/providers/publichd.py
+++ b/sickbeard/providers/publichd.py
@@ -106,8 +106,9 @@ class PublicHDProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                  
         
         return search_string
 
@@ -123,9 +124,10 @@ class PublicHDProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):    
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
     
         return search_string
 

--- a/sickbeard/providers/sceneaccess.py
+++ b/sickbeard/providers/sceneaccess.py
@@ -102,8 +102,10 @@ class SceneAccessProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)              
+                   
         return search_string
 
     ###################################################################################################
@@ -119,9 +121,10 @@ class SceneAccessProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -123,8 +123,9 @@ class ThePirateBayProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                          
         
         return search_string
 
@@ -141,9 +142,11 @@ class ThePirateBayProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):            
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
+                
     
         return search_string
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -93,8 +93,9 @@ class TorrentDayProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         
         return search_string
 
@@ -109,9 +110,10 @@ class TorrentDayProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
     
         return search_string    
 

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -111,8 +111,9 @@ class TorrentLeechProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         return search_string
     
     ###################################################################################################
@@ -128,9 +129,10 @@ class TorrentLeechProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         
         return search_string
     

--- a/sickbeard/providers/torrentshack.py
+++ b/sickbeard/providers/torrentshack.py
@@ -100,8 +100,9 @@ class TorrentShackProvider(generic.TorrentProvider):
                         search_string.append(ep_string)
                 else:
                     for show_name in set(show_name_helpers.allPossibleShowNames(show)):
-                        ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
-                        search_string.append(ep_string)                       
+                        for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                            ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': season, 'episodenumber': int(sqlEp["episode"])}
+                            search_string.append(ep_string)                      
         return search_string
 
     ###################################################################################################
@@ -117,9 +118,10 @@ class TorrentShackProvider(generic.TorrentProvider):
                 ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ str(ep_obj.airdate).replace('-', '.')
                 search_string.append(ep_string)
         else:
-            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):
-                ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
-                search_string.append(ep_string)
+            for show_name in set(show_name_helpers.allPossibleShowNames(ep_obj.show)):          
+                for ep_naming_type in sickbeard.config.naming_ep_type:                        
+                    ep_string = show_name_helpers.sanitizeSceneName(show_name) +' '+ ep_naming_type % {'seasonnumber': ep_obj.season, 'episodenumber': ep_obj.episode}
+                    search_string.append(ep_string)     
         return search_string    
  
     ###################################################################################################


### PR DESCRIPTION
Improved most providers to use all search patterns defined in sickbeard.config.naming_ep_type instead of just forcing sickbeard.config.naming_ep_type[2](SXXEXX pattern). This fixes issues with several british shows that use the 1x01 format. For example, Atlantis or any other show released by FoV.

Summary of changes:
- Before the changes these providers only performed searches using the S01E01 pattern. 
- After these changes these providers will use the following patterns: 1x01, s01e01, S01E01, 01x01

Do note that after the changes we can add new formats in sickbeard.config.naming_ep_type and all of these providers will pick them up.
