### PR TITLE
Unaired shows w/out airdate now show as unaired

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1240,9 +1240,12 @@ class TVEpisode(object):
             elif self.airdate == datetime.date.fromordinal(1):
                 if self.status == IGNORED:
                     logger.log(u"Episode has no air date, but it's already marked as ignored", logger.DEBUG)
+                elif str(self.season) == "0":
+                    logger.log(u"Special episode has no air date, automatically marking it skipped", logger.DEBUG)
+                    self.status = SKIPPED
                 else:
                     logger.log(u"Episode has no air date, automatically marking it skipped", logger.DEBUG)
-                    self.status = SKIPPED
+                    self.status = UNAIRED
             # if we don't have the file and the airdate is in the past
             else:
                 if self.status == UNAIRED:


### PR DESCRIPTION
Unaired shows that do not have an air date used to show as "Skipped", this ensures that they show as Unaired as expected
