### PR TITLE
Support custom URIs for Transmission

### DIFF
--- a/sickbeard/downloaders/transmission.py
+++ b/sickbeard/downloaders/transmission.py
@@ -72,7 +72,14 @@ def sendTORRENT(torrent):
         ###################################################################################################
         
         try:
-            tc = transmissionrpc.Client(host.hostname, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
+            address = host.hostname
+            if host.scheme:
+                address = host.scheme + '://' + address
+            if host.port:
+                address += ':' + str(host.port)
+            if host.path:
+                address += host.path
+            tc = transmissionrpc.Client(address, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
             logger.log("[Transmission] Login With Transmission, Successful.", logger.DEBUG)
         except transmissionrpc.TransmissionError, e:
             logger.log("[Transmission] Login With Transmission, Failed.",logger.ERROR)
@@ -127,7 +134,14 @@ def testAuthentication(host, username, password):
         return False, u"[Transmission] Host properties are not filled in correctly."
 
     try:
-        tc = transmissionrpc.Client(host.hostname, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
+        address = host.hostname
+        if host.scheme:
+            address = host.scheme + '://' + address
+        if host.port:
+            address += ':' + str(host.port)
+        if host.path:
+            address += host.path
+        tc = transmissionrpc.Client(address, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
         return True, u"[Transmission] Success: Connected and Authenticated. RPC version: " + str(tc.rpc_version)
     except Exception, e:
        return False, u"[Transmission] testAuthentication() Error: " + ex(e)


### PR DESCRIPTION
Previously the user provided transmission address was trimmed, and only the
hostname and port was used when creating the transmissionrpc client, which uses
the default '/tranmission/rpc' path in this case. Now the scheme, port, and the
path is also passed when creating the client, which parses this information, and
looks for tranmission at the address specified by the user.

My example: http://localhost:9091/torrent/rpc/
WIthout this change only localhost and 9091 is going into constructing the transmissionrpc client.
Cutting off the scheme makes the client use the default /tranmission/rpc/. But if the scheme is provided the constructor parses the address for the port, instead of using the one supplied in the parameter.
