### PR TITLE
Support custom URIs for Transmission

### DIFF
--- a/sickbeard/downloaders/transmission.py
+++ b/sickbeard/downloaders/transmission.py
@@ -56,7 +56,10 @@ def sendTORRENT(torrent):
         
     ###################################################################################################
     
-    host = urlparse(sickbeard.TORRENT_HOST)
+    host = sickbeard.TORRENT_HOST
+    if not host.startswith('http'):
+        host = 'http://' + sickbeard.TORRENT_HOST
+    host = urlparse(host)
     session = None
     if hasattr(torrent.provider, 'session'):
         session = torrent.provider.session
@@ -131,6 +134,8 @@ def sendTORRENT(torrent):
 def testAuthentication(host, username, password):
 
     try:
+        if not host.startswith('http'):
+            host = 'http://' + host
         host = urlparse(host)
     except Exception, e:
         return False, u"[Transmission] Host properties are not filled in correctly."


### PR DESCRIPTION
Previously the user provided transmission address was trimmed, and only the
hostname and port was used when creating the transmissionrpc client, which uses
the default '/tranmission/rpc' path in this case. Now the scheme, port, and the
path is also passed when creating the client, which parses this information, and
looks for tranmission at the address specified by the user.

Resubmit for #214
