### PR TITLE
modified URL openers so they do not check SSL certificates

### DIFF
--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -18,6 +18,7 @@
 
 
 import sys
+import ssl
 import urllib
 import os.path
 import ConfigParser
@@ -27,7 +28,7 @@ class AuthURLOpener(urllib.FancyURLopener):
         self.username = user
         self.password = pw
         self.numTries = 0
-        urllib.FancyURLopener.__init__(self)
+        urllib.FancyURLopener.__init__(self, context=ssl._create_unverified_context())
     
     def prompt_user_passwd(self, host, realm):
         if self.numTries == 0:

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -21,12 +21,17 @@
 import sickbeard
 
 import urllib
+import ssl
 import datetime
 
 from common import USER_AGENT, Quality
 
 class SickBeardURLopener(urllib.FancyURLopener):
     version = USER_AGENT
+    
+    def __init__(self):
+        # call the base class
+        urllib.FancyURLopener.__init__(self, context=ssl._create_unverified_context())
 
 class AuthURLOpener(SickBeardURLopener):
     """
@@ -44,7 +49,7 @@ class AuthURLOpener(SickBeardURLopener):
         self.numTries = 0
         
         # call the base class
-        urllib.FancyURLopener.__init__(self)
+        urllib.SickBeardURLopener.__init__(self)
 
     def prompt_user_passwd(self, host, realm):
         """

--- a/sickbeard/downloaders/deluge.py
+++ b/sickbeard/downloaders/deluge.py
@@ -17,6 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2, cookielib, StringIO, gzip
+import ssl
 import httplib
 import re
 
@@ -38,7 +39,7 @@ def _makeOpener(host, username, password):
                               uri=host,
                               user=username,
                               passwd=password)
-    opener = urllib2.build_opener(auth_handler)
+    opener = urllib2.build_opener(auth_handler, urllib2.HTTPSHandler(context=ssl._create_unverified_context()))
     urllib2.install_opener(opener)
 
     cookie_jar = cookielib.CookieJar()

--- a/sickbeard/downloaders/downloadstation.py
+++ b/sickbeard/downloaders/downloadstation.py
@@ -17,6 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2
+import ssl
 import httplib
 
 try:
@@ -63,7 +64,7 @@ class DownloadStationAPI(object):
 		logger.log(u"Request destination: " + self.url + script, logger.DEBUG)
 		logger.log(u"Request: " + str(request), logger.DEBUG)
 		try:
-			open_request = urllib2.urlopen(request)
+			open_request = urllib2.urlopen(request, context=ssl._create_unverified_context())
 			response = json.loads(open_request.read())
 			logger.log('response: ' + str(json.dumps(response).encode('utf-8')), logger.DEBUG)
 			if response['success'] == False:

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -29,6 +29,7 @@ import time
 import traceback
 import urllib
 import urllib2
+import ssl
 import zlib
 
 from httplib import BadStatusLine
@@ -145,7 +146,7 @@ def getURL(url, post_data=None, headers=[]):
     Returns a byte-string retrieved from the url provider.
     """
 
-    opener = urllib2.build_opener()
+    opener = urllib2.build_opener(urllib2.HTTPSHandler(context=ssl._create_unverified_context()))
     opener.addheaders = [('User-Agent', USER_AGENT), ('Accept-Encoding', 'gzip,deflate')]
     for cur_header in headers:
         opener.addheaders.append(cur_header)

--- a/sickbeard/notifiers/boxcar.py
+++ b/sickbeard/notifiers/boxcar.py
@@ -18,6 +18,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2
+import ssl
 import time
 
 import sickbeard
@@ -67,7 +68,7 @@ class BoxcarNotifier:
         # send the request to boxcar
         try:
             req = urllib2.Request(curUrl)
-            handle = urllib2.urlopen(req, data)
+            handle = urllib2.urlopen(req, data, context=ssl._create_unverified_context())
             handle.close()
             
         except urllib2.URLError, e:

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -17,6 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2
+import ssl
 import sickbeard
 import telnetlib
 import re
@@ -110,7 +111,7 @@ class NMJNotifier:
             try:
                 req = urllib2.Request(mount)
                 logger.log(u"Try to mount network drive via url: %s" % (mount), logger.DEBUG)
-                handle = urllib2.urlopen(req)
+                handle = urllib2.urlopen(req, context=ssl._create_unverified_context())
             except IOError, e:
                 logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
                 return False
@@ -129,7 +130,7 @@ class NMJNotifier:
         try:
             req = urllib2.Request(updateUrl)
             logger.log(u"Sending NMJ scan update command via url: %s" % (updateUrl), logger.DEBUG)
-            handle = urllib2.urlopen(req)
+            handle = urllib2.urlopen(req, context=ssl._create_unverified_context())
             response = handle.read()
         except IOError, e:
             logger.log(u"Warning: Couldn't contact Popcorn Hour on host %s: %s" % (host, e))

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -18,6 +18,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2,xml.dom.minidom
+import ssl
 from xml.dom.minidom import parseString
 import sickbeard
 import telnetlib
@@ -57,7 +58,7 @@ class NMJv2Notifier:
         try:
             url_loc = "http://" + host + ":8008/file_operation?arg0=list_user_storage_file&arg1=&arg2="+instance+"&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false"
             req = urllib2.Request(url_loc)
-            handle1 = urllib2.urlopen(req)
+            handle1 = urllib2.urlopen(req, context=ssl._create_unverified_context())
             response1 = handle1.read()
             xml = parseString(response1)
             time.sleep (300.0 / 1000.0)
@@ -66,7 +67,7 @@ class NMJv2Notifier:
                 xmlData=xmlTag.replace('<path>','').replace('</path>','').replace('[=]','')
                 url_db = "http://" + host + ":8008/metadata_database?arg0=check_database&arg1="+ xmlData
                 reqdb = urllib2.Request(url_db)
-                handledb = urllib2.urlopen(reqdb)
+                handledb = urllib2.urlopen(reqdb, context=ssl._create_unverified_context())
                 responsedb = handledb.read()
                 xmldb = parseString(responsedb)
                 returnvalue=xmldb.getElementsByTagName('returnValue')[0].toxml().replace('<returnValue>','').replace('</returnValue>','')
@@ -105,10 +106,10 @@ class NMJv2Notifier:
             logger.log(u"Try to mount network drive via url: %s" % (host), logger.DEBUG)
             prereq = urllib2.Request(url_scandir)
             req = urllib2.Request(url_updatedb)
-            handle1 = urllib2.urlopen(prereq)
+            handle1 = urllib2.urlopen(prereq, context=ssl._create_unverified_context())
             response1 = handle1.read()
             time.sleep (300.0 / 1000.0)
-            handle2 = urllib2.urlopen(req)
+            handle2 = urllib2.urlopen(req, context=ssl._create_unverified_context())
             response2 = handle2.read()
         except IOError, e:
             logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -18,6 +18,7 @@
 
 import urllib
 import urllib2
+import ssl
 import base64
 
 import sickbeard
@@ -76,7 +77,7 @@ class PLEXNotifier:
             else:
                 logger.log(u"Contacting Plex via url: " + url, logger.DEBUG)
 
-            response = urllib2.urlopen(req)
+            response = urllib2.urlopen(req, context=ssl._create_unverified_context())
 
             result = response.read().decode(sickbeard.SYS_ENCODING)
             response.close()
@@ -164,7 +165,7 @@ class PLEXNotifier:
 
             url = "http://%s/library/sections" % sickbeard.PLEX_SERVER_HOST
             try:
-                xml_sections = minidom.parse(urllib.urlopen(url))
+                xml_sections = minidom.parse(urllib.urlopen(url, context=ssl._create_unverified_context()))
             except IOError, e:
                 logger.log(u"Error while trying to contact Plex Media Server: " + ex(e), logger.ERROR)
                 return False
@@ -178,7 +179,7 @@ class PLEXNotifier:
                 if s.getAttribute('type') == "show":
                     url = "http://%s/library/sections/%s/refresh" % (sickbeard.PLEX_SERVER_HOST, s.getAttribute('key'))
                     try:
-                        urllib.urlopen(url)
+                        urllib.urlopen(url, context=ssl._create_unverified_context())
                     except Exception, e:
                         logger.log(u"Error updating library section for Plex Media Server: " + ex(e), logger.ERROR)
                         return False

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -19,6 +19,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 import urllib, urllib2
+import ssl
 import time
 
 import sickbeard
@@ -65,7 +66,7 @@ class PushoverNotifier:
         # send the request to pushover
         try:
             req = urllib2.Request(curUrl)
-            handle = urllib2.urlopen(req, data)
+            handle = urllib2.urlopen(req, data, context=ssl._create_unverified_context())
             handle.close()
             
         except urllib2.URLError, e:

--- a/sickbeard/notifiers/pytivo.py
+++ b/sickbeard/notifiers/pytivo.py
@@ -21,6 +21,7 @@ import sickbeard
 
 from urllib import urlencode
 from urllib2 import Request, urlopen, URLError
+import ssl
 
 from sickbeard import logger
 from sickbeard import encodingKludge as ek
@@ -82,7 +83,7 @@ class pyTivoNotifier:
         request = Request( requestUrl )
 
         try:
-            response = urlopen(request) #@UnusedVariable   
+            response = urlopen(request, context=ssl._create_unverified_context()) #@UnusedVariable   
         except URLError, e:
             if hasattr(e, 'reason'):
                 logger.log(u"pyTivo notification: Error, failed to reach a server")

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -18,6 +18,7 @@
 
 
 import urllib2
+import ssl
 
 from hashlib import sha1
 
@@ -133,7 +134,7 @@ class TraktNotifier:
         # request the URL from trakt and parse the result as json
         try:
             logger.log("trakt_notifier: Calling method http://api.trakt.tv/" + method + ", with data" + encoded_data, logger.DEBUG)
-            stream = urllib2.urlopen("http://api.trakt.tv/" + method, encoded_data)
+            stream = urllib2.urlopen("http://api.trakt.tv/" + method, encoded_data, context=ssl._create_unverified_context())
             resp = stream.read()
 
             resp = json.loads(resp)

--- a/sickbeard/notifiers/xbmc.py
+++ b/sickbeard/notifiers/xbmc.py
@@ -18,6 +18,7 @@
 
 import urllib
 import urllib2
+import ssl
 import socket
 import base64
 import time
@@ -196,7 +197,7 @@ class XBMCNotifier:
             else:
                 logger.log(u"Contacting XBMC via url: " + fixStupidEncodings(url), logger.DEBUG)
 
-            response = urllib2.urlopen(req)
+            response = urllib2.urlopen(req, context=ssl._create_unverified_context())
             result = response.read().decode(sickbeard.SYS_ENCODING)
             response.close()
 
@@ -337,7 +338,7 @@ class XBMCNotifier:
                 logger.log(u"Contacting XBMC via url: " + fixStupidEncodings(url), logger.DEBUG)
 
             try:
-                response = urllib2.urlopen(req)
+                response = urllib2.urlopen(req, context=ssl._create_unverified_context())
             except urllib2.URLError, e:
                 logger.log(u"Error while trying to retrieve XBMC API version for " + host + ": " + ex(e), logger.WARNING)
                 return False

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -20,6 +20,7 @@
 
 import re
 import urllib, urllib2, cookielib
+import ssl
 import sys
 import datetime
 import os
@@ -177,7 +178,7 @@ class BTDIGGProvider(generic.TorrentProvider):
         logger.log("[BTDigg] Requesting - " + url)
         try:
             #response = helpers.getURL(url, headers)
-            response = urllib.urlopen(url)
+            response = urllib.urlopen(url, context=ssl._create_unverified_context())
         except (urllib2.HTTPError, IOError, Exception), e:
             logger.log("[BTDigg] getURL() Error loading " + self.name + " URL: " + str(sys.exc_info()) + " - " + ex(e), logger.ERROR)
             return None

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -25,6 +25,7 @@ import sickbeard
 
 from lib import MultipartPostHandler
 import urllib2, cookielib
+import ssl
 try:
     import json
 except ImportError:
@@ -75,13 +76,14 @@ def sendNZB(nzb):
     try:
         # if we have the URL to an NZB then we've built up the SAB API URL already so just call it 
         if nzb.resultType == "nzb":
-            f = urllib.urlopen(url)
+            f = urllib.urlopen(url, context=ssl._create_unverified_context())
         
         # if we are uploading the NZB data to SAB then we need to build a little POST form and send it
         elif nzb.resultType == "nzbdata":
             cookies = cookielib.CookieJar()
             opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies),
-                                          MultipartPostHandler.MultipartPostHandler)
+                                          MultipartPostHandler.MultipartPostHandler,
+                                          urllib2.HTTPSHandler(context=ssl._create_unverified_context()))
             req = urllib2.Request(url,
                                   multiPartParams,
                                   headers={'User-Agent': USER_AGENT})
@@ -158,7 +160,7 @@ def _checkSabResponse(f):
 
 def _sabURLOpenSimple(url):
     try:
-        f = urllib.urlopen(url)
+        f = urllib.urlopen(url, context=ssl._create_unverified_context())
     except (EOFError, IOError), e:
         logger.log(u"Unable to connect to SAB: " + ex(e), logger.ERROR)
         return False, "Unable to connect"

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -41,6 +41,7 @@ from sickbeard.providers.generic import GenericProvider
 
 
 import urllib2
+import ssl
 
 def _downloadResult(result):
     """
@@ -125,7 +126,7 @@ def snatchEpisode(result, endStatus=SNATCHED):
             allUrls = result.url.split(";", 3)
             for url in allUrls:
                 try:
-                    urllib2.urlopen(url)
+                    urllib2.urlopen(url, context=ssl._create_unverified_context())
                     result.url = url
                     break
                 except Exception:


### PR DESCRIPTION
This restores the sickbeard behaviour from before https://www.python.org/dev/peps/pep-0476/ (which enabled certificate verification by default in python's urllib)

Because of the default certificate verification introduced in PEP-0476, sickbeard could no longer connect with sabnzbd, which uses a self-signed certificate, and sabnzbd could no longer connect with sickbeard through the autoProcessTV.py post-processing script because sickbeard also uses a self-signed certificate.

This was also reported for midgetspy's sickbeard in this issue https://code.google.com/p/sickbeard/issues/detail?id=2551

I went through the code again and applied this fix anywhere I could find any code that opened a URL through urllib or urllib2. This is done in many different parts of sickbeard, so I can't really test them all. But the fix shouldn't have much of an impact since it's just ignored if the provided URL isn't for an HTTPS connection and any HTTPS connection would have failed already without this fix. If SSL certificate validation is desired after all in some locations, you can explicitly set the context to do so. 

(Note: I screwed something up in my branch so I had to re-create this PR)