### PR TITLE
Revert kickass URL to "kickass.to" (from "kickass.so")

### DIFF
--- a/sickbeard/providers/kickass.py
+++ b/sickbeard/providers/kickass.py
@@ -48,7 +48,7 @@ class KickAssProvider(generic.TorrentProvider):
         self.name = "KickAss"
         self.session = None
         self.supportsBacklog = True
-        self.url = "http://kickass.so/"
+        self.url = "http://kickass.to/"
         logger.log("[" + self.name + "] initializing...")
         
     ###################################################################################################


### PR DESCRIPTION
Updated the default URL for kickass, since the .so domain no longer seems to be available