### PR TITLE
Revert kickass URL to "kickass.to" (from "kickass.so")

### DIFF
--- a/sickbeard/providers/kickass.py
+++ b/sickbeard/providers/kickass.py
@@ -48,7 +48,7 @@ class KickAssProvider(generic.TorrentProvider):
         self.name = "KickAss"
         self.session = None
         self.supportsBacklog = True
-        self.url = "http://kickass.so/"
+        self.url = "http://kickass.to/"
         logger.log("[" + self.name + "] initializing...")
         
     ###################################################################################################


### PR DESCRIPTION
Sorry about the earlier PR (#233), I often forget to check the base branch.

About the possibility of using "kat.ph" as URL, mentioned by @gitrickm in the earlier PR:
Since "kickass.to" is the actual URL to Kickass, I use that one as default. But this provider has the option of adding an alternative URL so there's nothing stopping anyone from using "kat.ph", "kat.proxy" or any other URL that works best for them.