### PR TITLE
Updated TorrentShack URL.

### DIFF
--- a/sickbeard/providers/torrentshack.py
+++ b/sickbeard/providers/torrentshack.py
@@ -47,7 +47,7 @@ class TorrentShackProvider(generic.TorrentProvider):
         self.name = "TorrentShack"
         self.session = None
         self.supportsBacklog = True
-        self.url = 'https://torrentshack.eu/'
+        self.url = 'https://theshack.us.to/'
         logger.log("[" + self.name + "] initializing...")
     
     ###################################################################################################


### PR DESCRIPTION
.eu domain suspended refer https://torrentfreak.com/eurid-suspends-torrentshack-domain-name-after-complaint-150213/