### PR TITLE
Changed BitHDTV to HTTPS

### DIFF
--- a/sickbeard/providers/bithdtv.py
+++ b/sickbeard/providers/bithdtv.py
@@ -48,7 +48,7 @@ class BitHDTVProvider(generic.TorrentProvider):
         self.name = "BitHDTV"
         self.session = None
         self.supportsBacklog = True
-        self.url = 'http://www.bit-hdtv.com/'
+        self.url = 'https://www.bit-hdtv.com/'
         logger.log("[" + self.name + "] initializing...")
         
     ###################################################################################################


### PR DESCRIPTION
BitHDTV automatically redirects you to HTTPS now. Have not tested this myself, but buddy of mine says the change to HTTPS helped solve "No data returned" error.