### PR TITLE
modified URL openers so they do not check SSL certificates

### DIFF
--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -18,6 +18,8 @@
 
 
 import sys
+if sys.version_info >= (2, 7, 9):
+    import ssl
 import urllib
 import os.path
 import ConfigParser
@@ -27,7 +29,10 @@ class AuthURLOpener(urllib.FancyURLopener):
         self.username = user
         self.password = pw
         self.numTries = 0
-        urllib.FancyURLopener.__init__(self)
+        if sys.version_info >= (2, 7, 9):
+            urllib.FancyURLopener.__init__(self, context=ssl._create_unverified_context())
+        else:
+            urllib.FancyURLopener.__init__(self)
     
     def prompt_user_passwd(self, host, realm):
         if self.numTries == 0:

--- a/autoProcessTV/autoProcessTV.py
+++ b/autoProcessTV/autoProcessTV.py
@@ -77,7 +77,7 @@ def processEpisode(dirName, nzbName=None):
     
     params['quiet'] = 1
 
-    params['dir'] = dirName
+    params['directory'] = dirName
     if nzbName != None:
         params['nzbName'] = nzbName
         

--- a/data/interfaces/default/home_postprocess.tmpl
+++ b/data/interfaces/default/home_postprocess.tmpl
@@ -8,7 +8,7 @@
 #include $os.path.join($sickbeard.PROG_DIR, "data/interfaces/default/inc_top.tmpl")
 
 <form name="processForm" method="post" action="processEpisode">
-Enter the folder containing the episode: <input type="text" name="dir" id="episodeDir" size="50" /> <input type="submit" class="btn" value="Process" />
+Enter the folder containing the episode: <input type="text" name="directory" id="episodeDir" size="50" /> <input type="submit" class="btn" value="Process" />
 </form>
 <br />
 

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -19,52 +19,9 @@
 
 
 import sickbeard
-
-import urllib
 import datetime
+from common import Quality
 
-from common import USER_AGENT, Quality
-
-class SickBeardURLopener(urllib.FancyURLopener):
-    version = USER_AGENT
-
-class AuthURLOpener(SickBeardURLopener):
-    """
-    URLOpener class that supports http auth without needing interactive password entry.
-    If the provided username/password don't work it simply fails.
-    
-    user: username to use for HTTP auth
-    pw: password to use for HTTP auth
-    """
-    def __init__(self, user, pw):
-        self.username = user
-        self.password = pw
-
-        # remember if we've tried the username/password before
-        self.numTries = 0
-        
-        # call the base class
-        urllib.FancyURLopener.__init__(self)
-
-    def prompt_user_passwd(self, host, realm):
-        """
-        Override this function and instead of prompting just give the
-        username/password that were provided when the class was instantiated.
-        """
-
-        # if this is the first try then provide a username/password
-        if self.numTries == 0:
-            self.numTries = 1
-            return (self.username, self.password)
-        
-        # if we've tried before then return blank which cancels the request
-        else:
-            return ('', '')
-
-    # this is pretty much just a hack for convenience
-    def openit(self, url):
-        self.numTries = 0
-        return SickBeardURLopener.open(self, url)
 
 class SearchResult:
     """

--- a/sickbeard/downloaders/downloadstation.py
+++ b/sickbeard/downloaders/downloadstation.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2
-import httplib
+from urllib import urlencode
+from urllib2 import Request, HTTPError, URLError
+from httplib import InvalidURL
 
 try:
     import json
@@ -26,7 +27,7 @@ except ImportError:
 
 import sickbeard
 from sickbeard import logger
-from sickbeard.exceptions import ex
+from sickbeard import helpers
 from urlparse import urlparse
 
 class DownloadStationAPI(object):
@@ -39,45 +40,45 @@ class DownloadStationAPI(object):
         logger.log(u"Creating DownloadStation API object for " + self.url, logger.DEBUG)
 
         post_data = {
-			'api' : 'SYNO.API.Auth',
-			'method' : 'login',
-			'account' : username,
-			'passwd' : password,
-			'session' : 'DownloadStation',
-			'format' : 'sid',
-			'version' : 2
+            'api' : 'SYNO.API.Auth',
+            'method' : 'login',
+            'account' : username,
+            'passwd' : password,
+            'session' : 'DownloadStation',
+            'format' : 'sid',
+            'version' : 2
         }
         response = self._request('auth.cgi', post_data)
         if response != False:
-			logger.log(u"Session ID = " + str(response['sid']), logger.DEBUG)
-			self.sid = response['sid']
-			self.url = self.url + "DownloadStation/"
+            logger.log(u"Session ID = " + str(response['sid']), logger.DEBUG)
+            self.sid = response['sid']
+            self.url = self.url + "DownloadStation/"
         else:
-			raise Exception("Unable to get a session from SYNO.API.Auth, check credentials")
+            raise Exception("Unable to get a session from SYNO.API.Auth, check credentials")
 
     def _request(self, script, post_data):
-		logger.log(u"Creating DownloadStation API " + script + " request: " + str(post_data), logger.DEBUG)
-		post_data.update({'_sid' : self.sid})
-		headers = {'User-agent' : 'sick-beard-downloadstation-client/1.0'}
-		request = urllib2.Request(self.url + script, urllib.urlencode(post_data), headers)
-		logger.log(u"Request destination: " + self.url + script, logger.DEBUG)
-		logger.log(u"Request: " + str(request), logger.DEBUG)
-		try:
-			open_request = urllib2.urlopen(request)
-			response = json.loads(open_request.read())
-			logger.log('response: ' + str(json.dumps(response).encode('utf-8')), logger.DEBUG)
-			if response['success'] == False:
-				logger.log(u"Request Error: " + str(response['error']['code']), logger.DEBUG)
-				return False
-			else:
-				return True if not 'data' in response else response['data']
-		except httplib.InvalidURL, e:
-			logger.log(u"Invalid host, check your config " + str(e), logger.ERROR)
-		except urllib2.HTTPError, e:
-			logger.log(u"DownloadStationAPI HTTPError: " + str(e), logger.ERROR)
-		except urllib2.URLError, e:
-			logger.log(u"Unable to connect to DownloadStation " + str(e), logger.ERROR)
-		return False
+        logger.log(u"Creating DownloadStation API " + script + " request: " + str(post_data), logger.DEBUG)
+        post_data.update({'_sid' : self.sid})
+        headers = {'User-agent' : 'sick-beard-downloadstation-client/1.0'}
+        request = Request(self.url + script, urlencode(post_data), headers)
+        logger.log(u"Request destination: " + self.url + script, logger.DEBUG)
+        logger.log(u"Request: " + str(request), logger.DEBUG)
+        try:
+            open_request = helpers.getURLFileLike(request)
+            response = json.loads(open_request.read())
+            logger.log('response: ' + str(json.dumps(response).encode('utf-8')), logger.DEBUG)
+            if response['success'] == False:
+                logger.log(u"Request Error: " + str(response['error']['code']), logger.DEBUG)
+                return False
+            else:
+                return True if not 'data' in response else response['data']
+        except InvalidURL, e:
+            logger.log(u"Invalid host, check your config " + str(e), logger.ERROR)
+        except HTTPError, e:
+            logger.log(u"DownloadStationAPI HTTPError: " + str(e), logger.ERROR)
+        except URLError, e:
+            logger.log(u"Unable to connect to DownloadStation " + str(e), logger.ERROR)
+        return False
 
     def add_download(self, uri, destination):
         logger.log(u"Adding Download:" + uri, logger.DEBUG)
@@ -99,17 +100,17 @@ class DownloadStationAPI(object):
             'method': 'list',
             'version' : 1
         }
-		# the Download Station API doesnt return an ID when we add the torrent
-		# list all the download tasks that match our uri and pause them all
-        list = self._request('task.cgi', post_data)
-        if list:
+        # the Download Station API doesnt return an ID when we add the torrent
+        # downloadTaskList all the download tasks that match our uri and pause them all
+        downloadTaskList = self._request('task.cgi', post_data)
+        if downloadTaskList:
             post_data['method'] = 'pause'
-            tasks = [task['id'] for task in list['tasks'] if task['additional']['detail']['uri'] == uri]
+            tasks = [task['id'] for task in downloadTaskList['tasks'] if task['additional']['detail']['uri'] == uri]
             paused = 0 #number of downloads we successfully pause
             for task in tasks:
-				post_data['id'] = task
-				if self._request('task.cgi', post_data):
-					paused = paused + 1
+                post_data['id'] = task
+                if self._request('task.cgi', post_data):
+                    paused = paused + 1
             logger.log("Paused " + str(paused) + " download tasks", logger.DEBUG)
             return bool(paused)
         return False
@@ -123,24 +124,24 @@ def sendDownload(download):
 
     try:
         ds = DownloadStationAPI(host.hostname, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
-        torrent = ds.add_download(download.url, sickbeard.TORRENT_PATH)
+        ds.add_download(download.url, sickbeard.TORRENT_PATH)
         if sickbeard.TORRENT_PAUSED:
-			ds.pause_download(download.url)
+            ds.pause_download(download.url)
         return True
     except Exception, e:
         logger.log("Unknown failure sending Torrent to Download Station. Return text is: " + str(e), logger.ERROR)
         return False
 
 def testAuthentication(host, username, password):
-	logger.log("Testing authentication to " + str(host) + " TORRENT_HOST=" + str(sickbeard.TORRENT_HOST), logger.DEBUG)
-	try:
-		host = urlparse(host)
-	except Exception, e:
-		return False, u"Host properties are not filled in correctly, port is missing."
+    logger.log("Testing authentication to " + str(host) + " TORRENT_HOST=" + str(sickbeard.TORRENT_HOST), logger.DEBUG)
+    try:
+        host = urlparse(host)
+    except Exception, e:
+        return False, u"Host properties are not filled in correctly, port is missing."
 
-	try:
-		ds = DownloadStationAPI(host.hostname, host.port, username, password)
-		return bool(ds.sid), u"Success: Connected and Authenticated."
+    try:
+        ds = DownloadStationAPI(host.hostname, host.port, username, password)
+        return bool(ds.sid), u"Success: Connected and Authenticated."
 
-	except Exception, e:
-		return False, u"Error: Unable to connect to Download Station. " + str(e)
+    except Exception, e:
+        return False, u"Error: Unable to connect to Download Station. " + str(e)

--- a/sickbeard/downloaders/transmission.py
+++ b/sickbeard/downloaders/transmission.py
@@ -153,6 +153,6 @@ def testAuthentication(host, username, password):
         tc = transmissionrpc.Client(address, host.port, sickbeard.TORRENT_USERNAME, sickbeard.TORRENT_PASSWORD)
         return True, u"[Transmission] Success: Connected and Authenticated. RPC version: " + str(tc.rpc_version)
     except Exception, e:
-       return False, u"[Transmission] testAuthentication() Error: " + ex(e)
+        return False, u"[Transmission] testAuthentication() Error: " + ex(e)
 
 ###################################################################################################

--- a/sickbeard/downloaders/utorrent.py
+++ b/sickbeard/downloaders/utorrent.py
@@ -25,6 +25,7 @@ from hashlib import sha1
 
 from lib import requests
 from lib.bencode import bencode, bdecode
+from base64 import b16encode, b32decode
 
 from sickbeard import logger
 from sickbeard.exceptions import ex
@@ -48,20 +49,20 @@ def _authToken(session=None,host=None, username=None, password=None):
 ###################################################################################################
 
 def _TorrentHash(url=None,torrent=None):
-    hash=None
+    torrentHash=None
     if url.startswith('magnet'):
-        hash = re.search('urn:btih:([\w]{32,40})', url).group(1)
-        if len(hash) == 32:
-            hash = b16encode(b32decode(hash)).upper()
+        torrentHash = re.search('urn:btih:([\w]{32,40})', url).group(1)
+        if len(torrentHash) == 32:
+            torrentHash = b16encode(b32decode(torrentHash)).upper()
     else:
         info = bdecode(torrent)["info"]
-        hash = sha1(bencode(info)).hexdigest().upper()
-    return hash
+        torrentHash = sha1(bencode(info)).hexdigest().upper()
+    return torrentHash
 
 ###################################################################################################
 
 def testAuthentication(host=None, username=None, password=None):
-    auth,session = _authToken(None,host,username,password)
+    auth = _authToken(None,host,username,password)[0]
     if auth:
         return True,u"[uTorrent] Authenication Successful."
     return False,u"[uTorrent] Authenication Failed."
@@ -87,7 +88,6 @@ def sendTORRENT(torrent):
     
     ###################################################################################################
     
-    session = None
     torrent_hash = None
     params = {}
     files = {}

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -165,6 +165,12 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
     @param throw_exc: throw the exception that was caught instead of None
     @return: the file-like object retrieved from the URL or None (or the exception) if it could not be retrieved
     """
+    # get the name string for logging purposes
+    if isinstance(url, urllib2.Request):
+        name = url.get_full_url()
+    else:
+        name = url
+    
     # configure the OpenerDirector appropriately
     if not validate and sys.version_info >= (2, 7, 9):
             opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies),
@@ -176,7 +182,7 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         # Before python 2.7.9, there was no built-in way to validate SSL certificates
         # Since our default is not to validate, it is of low priority to make it available here
         if validate and sys.version_info < (2, 7, 9):
-            logger.log(u"The SSL certificate will not be validated for " + url + u"(python 2.7.9+ required)", logger.MESSAGE)
+            logger.log(u"The SSL certificate will not be validated for " + name + u"(python 2.7.9+ required)", logger.MESSAGE)
 
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies),
                                       MultipartPostHandler.MultipartPostHandler,
@@ -192,42 +198,42 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         return opener.open(url, timeout=30)
 
     except urllib2.HTTPError, e:
-        logger.log(u"HTTP error " + str(e.code) + u" while loading URL " + url, logger.WARNING)
+        logger.log(u"HTTP error " + str(e.code) + u" while loading URL " + name, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except urllib2.URLError, e:
-        logger.log(u"URL error " + str(e.reason) + u" while loading URL " + url, logger.WARNING)
+        logger.log(u"URL error " + str(e.reason) + u" while loading URL " + name, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except BadStatusLine:
-        logger.log(u"BadStatusLine error while loading URL " + url, logger.WARNING)
+        logger.log(u"BadStatusLine error while loading URL " + name, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except socket.timeout:
-        logger.log(u"Timed out while loading URL " + url, logger.WARNING)
+        logger.log(u"Timed out while loading URL " + name, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except ValueError:
-        logger.log(u"Unknown error while loading URL " + url, logger.WARNING)
+        logger.log(u"Unknown error while loading URL " + name, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except Exception:
-        logger.log(u"Unknown exception while loading URL " + url + u": " + traceback.format_exc(), logger.WARNING)
+        logger.log(u"Unknown exception while loading URL " + name + u": " + traceback.format_exc(), logger.WARNING)
         if throw_exc:
             raise 
         else:

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -176,7 +176,7 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         # Before python 2.7.9, there was no built-in way to validate SSL certificates
         # Since our default is not to validate, it is of low priority to make it available here
         if validate and sys.version_info < (2, 7, 9):
-            logger.log(u"The SSL certificate will not be validated for " + url + "(python 2.7.9+ required)", logger.MESSAGE)
+            logger.log(u"The SSL certificate will not be validated for " + url + u"(python 2.7.9+ required)", logger.MESSAGE)
 
         opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookies),
                                       MultipartPostHandler.MultipartPostHandler,
@@ -192,14 +192,14 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
         return opener.open(url, timeout=30)
 
     except urllib2.HTTPError, e:
-        logger.log(u"HTTP error " + str(e.code) + " while loading URL " + url, logger.WARNING)
+        logger.log(u"HTTP error " + str(e.code) + u" while loading URL " + url, logger.WARNING)
         if throw_exc:
             raise 
         else:
             return None
 
     except urllib2.URLError, e:
-        logger.log(u"URL error " + str(e.reason) + " while loading URL " + url, logger.WARNING)
+        logger.log(u"URL error " + str(e.reason) + u" while loading URL " + url, logger.WARNING)
         if throw_exc:
             raise 
         else:
@@ -227,7 +227,7 @@ def getURLFileLike(url, validate=False, cookies = cookielib.CookieJar(), passwor
             return None
 
     except Exception:
-        logger.log(u"Unknown exception while loading URL " + url + ": " + traceback.format_exc(), logger.WARNING)
+        logger.log(u"Unknown exception while loading URL " + url + u": " + traceback.format_exc(), logger.WARNING)
         if throw_exc:
             raise 
         else:
@@ -320,7 +320,7 @@ def searchDBForShow(regShowName):
                 logger.log(u"Unable to match a record in the DB for " + showName, logger.DEBUG)
                 continue
             elif len(sqlResults) > 1:
-                logger.log(u"Multiple results for " + showName + " in the DB, unable to match show name", logger.DEBUG)
+                logger.log(u"Multiple results for " + showName + u" in the DB, unable to match show name", logger.DEBUG)
                 continue
             else:
                 return (int(sqlResults[0]["tvdb_id"]), sqlResults[0]["show_name"])
@@ -389,16 +389,16 @@ def make_dirs(path):
     parents
     """
 
-    logger.log(u"Checking if the path " + path + " already exists", logger.DEBUG)
+    logger.log(u"Checking if the path " + path + u" already exists", logger.DEBUG)
 
     if not ek.ek(os.path.isdir, path):
         # Windows, create all missing folders
         if os.name == 'nt' or os.name == 'ce':
             try:
-                logger.log(u"Folder " + path + " didn't exist, creating it", logger.DEBUG)
+                logger.log(u"Folder " + path + u" didn't exist, creating it", logger.DEBUG)
                 ek.ek(os.makedirs, path)
             except (OSError, IOError), e:
-                logger.log(u"Failed creating " + path + " : " + ex(e), logger.ERROR)
+                logger.log(u"Failed creating " + path + u" : " + ex(e), logger.ERROR)
                 return False
 
         # not Windows, create all missing folders and set permissions
@@ -415,14 +415,14 @@ def make_dirs(path):
                     continue
 
                 try:
-                    logger.log(u"Folder " + sofar + " didn't exist, creating it", logger.DEBUG)
+                    logger.log(u"Folder " + sofar + u" didn't exist, creating it", logger.DEBUG)
                     ek.ek(os.mkdir, sofar)
                     # use normpath to remove end separator, otherwise checks permissions against itself
                     chmodAsParent(ek.ek(os.path.normpath, sofar))
                     # do the library update for synoindex
                     notifiers.synoindex_notifier.addFolder(sofar)
                 except (OSError, IOError), e:
-                    logger.log(u"Failed creating " + sofar + " : " + ex(e), logger.ERROR)
+                    logger.log(u"Failed creating " + sofar + u" : " + ex(e), logger.ERROR)
                     return False
 
     return True
@@ -453,10 +453,10 @@ def rename_ep_file(cur_path, new_path, old_path_length=0):
 
     # move the file
     try:
-        logger.log(u"Renaming file from " + cur_path + " to " + new_path)
+        logger.log(u"Renaming file from " + cur_path + u" to " + new_path)
         ek.ek(os.rename, cur_path, new_path)
     except (OSError, IOError), e:
-        logger.log(u"Failed renaming " + cur_path + " to " + new_path + ": " + ex(e), logger.ERROR)
+        logger.log(u"Failed renaming " + cur_path + u" to " + new_path + ": " + ex(e), logger.ERROR)
         return False
 
     # clean up any old folders that are empty
@@ -492,7 +492,7 @@ def delete_empty_folders(check_empty_dir, keep_dir=None):
                 # do the library update for synoindex
                 notifiers.synoindex_notifier.deleteFolder(check_empty_dir)
             except OSError, e:
-                logger.log(u"Unable to delete " + check_empty_dir + ": " + repr(e) + " / " + str(e), logger.WARNING)
+                logger.log(u"Unable to delete " + check_empty_dir + u": " + repr(e) + u" / " + str(e), logger.WARNING)
                 break
             check_empty_dir = ek.ek(os.path.dirname, check_empty_dir)
         else:
@@ -506,7 +506,7 @@ def chmodAsParent(childPath):
     parentPath = ek.ek(os.path.dirname, childPath)
 
     if not parentPath:
-        logger.log(u"No parent path provided in " + childPath + ", unable to get permissions from it", logger.DEBUG)
+        logger.log(u"No parent path provided in " + childPath + u", unable to get permissions from it", logger.DEBUG)
         return
 
     parentMode = stat.S_IMODE(os.stat(parentPath)[stat.ST_MODE])
@@ -526,7 +526,7 @@ def chmodAsParent(childPath):
     user_id = os.geteuid()  # @UndefinedVariable - only available on UNIX
 
     if user_id != 0 and user_id != childPath_owner:
-        logger.log(u"Not running as root or owner of " + childPath + ", not trying to set permissions", logger.DEBUG)
+        logger.log(u"Not running as root or owner of " + childPath + u", not trying to set permissions", logger.DEBUG)
         return
 
     try:
@@ -564,7 +564,7 @@ def fixSetGroupID(childPath):
         user_id = os.geteuid()  # @UndefinedVariable - only available on UNIX
 
         if user_id != 0 and user_id != childPath_owner:
-            logger.log(u"Not running as root or owner of " + childPath + ", not trying to set the set-group-ID", logger.DEBUG)
+            logger.log(u"Not running as root or owner of " + childPath + u", not trying to set the set-group-ID", logger.DEBUG)
             return
 
         try:
@@ -673,7 +673,7 @@ def parse_xml(data, del_xmlns=False):
     try:
         parsedXML = etree.fromstring(data)
     except Exception, e:
-        logger.log(u"Error trying to parse xml data: " + data + " to Elementtree, Error: " + ex(e), logger.DEBUG)
+        logger.log(u"Error trying to parse xml data: " + data + u" to Elementtree, Error: " + ex(e), logger.DEBUG)
         parsedXML = None
 
     return parsedXML
@@ -713,22 +713,22 @@ def backupVersionedFile(old_file, version):
 
     while not ek.ek(os.path.isfile, new_file):
         if not ek.ek(os.path.isfile, old_file):
-            logger.log(u"Not creating backup, " + old_file + " doesn't exist", logger.DEBUG)
+            logger.log(u"Not creating backup, " + old_file + u" doesn't exist", logger.DEBUG)
             break
 
         try:
-            logger.log(u"Trying to back up " + old_file + " to " + new_file, logger.DEBUG)
+            logger.log(u"Trying to back up " + old_file + u" to " + new_file, logger.DEBUG)
             shutil.copy(old_file, new_file)
             logger.log(u"Backup done", logger.DEBUG)
             break
         except Exception, e:
-            logger.log(u"Error while trying to back up " + old_file + " to " + new_file + " : " + ex(e), logger.WARNING)
+            logger.log(u"Error while trying to back up " + old_file + u" to " + new_file + " : " + ex(e), logger.WARNING)
             numTries += 1
             time.sleep(1)
             logger.log(u"Trying again.", logger.DEBUG)
 
         if numTries >= 10:
-            logger.log(u"Unable to back up " + old_file + " to " + new_file + " please do it manually.", logger.ERROR)
+            logger.log(u"Unable to back up " + old_file + u" to " + new_file + u" please do it manually.", logger.ERROR)
             return False
 
     return True

--- a/sickbeard/notifiers/boxcar.py
+++ b/sickbeard/notifiers/boxcar.py
@@ -17,7 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2
+from urllib import urlencode
+from urllib2 import Request, URLError
 import time
 
 import sickbeard
@@ -51,12 +52,12 @@ class BoxcarNotifier:
 
         # if this is a subscription notification then act accordingly
         if subscribe:
-            data = urllib.urlencode({'email': email})
+            data = urlencode({'email': email})
             curUrl = curUrl + "/subscribe"
         
         # for normal requests we need all these parameters
         else:
-            data = urllib.urlencode({
+            data = urlencode({
                 'email': email,
                 'notification[from_screen_name]': title,
                 'notification[message]': msg.encode('utf-8'),
@@ -66,11 +67,11 @@ class BoxcarNotifier:
 
         # send the request to boxcar
         try:
-            req = urllib2.Request(curUrl)
-            handle = urllib2.urlopen(req, data)
+            req = Request(curUrl, data)
+            handle = sickbeard.helpers.getURLFileLike(req, throw_exc=True)
             handle.close()
             
-        except urllib2.URLError, e:
+        except URLError, e:
             # if we get an error back that doesn't have an error code then who knows what's really happening
             if not hasattr(e, 'code'):
                 logger.log("Boxcar notification failed." + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2
+from urllib import urlencode
 import sickbeard
 import telnetlib
 import re
@@ -108,9 +108,8 @@ class NMJNotifier:
         # if a mount URL is provided then attempt to open a handle to that URL
         if mount:
             try:
-                req = urllib2.Request(mount)
                 logger.log(u"Try to mount network drive via url: %s" % (mount), logger.DEBUG)
-                handle = urllib2.urlopen(req)
+                handle = sickbeard.helpers.getURLFileLike(mount, throw_exc=True)
             except IOError, e:
                 logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
                 return False
@@ -122,14 +121,13 @@ class NMJNotifier:
             "arg1": database,
             "arg2": "background",
             "arg3": ""}
-        params = urllib.urlencode(params)
+        params = urlencode(params)
         updateUrl = UPDATE_URL % {"host": host, "params": params}
 
         # send the request to the server
         try:
-            req = urllib2.Request(updateUrl)
             logger.log(u"Sending NMJ scan update command via url: %s" % (updateUrl), logger.DEBUG)
-            handle = urllib2.urlopen(req)
+            handle = sickbeard.helpers.getURLFileLike(updateUrl, throw_exc=True)
             response = handle.read()
         except IOError, e:
             logger.log(u"Warning: Couldn't contact Popcorn Hour on host %s: %s" % (host, e))

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -17,11 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2,xml.dom.minidom
 from xml.dom.minidom import parseString
 import sickbeard
-import telnetlib
-import re
 import time
 
 from sickbeard import logger
@@ -56,8 +53,7 @@ class NMJv2Notifier:
         """
         try:
             url_loc = "http://" + host + ":8008/file_operation?arg0=list_user_storage_file&arg1=&arg2="+instance+"&arg3=20&arg4=true&arg5=true&arg6=true&arg7=all&arg8=name_asc&arg9=false&arg10=false"
-            req = urllib2.Request(url_loc)
-            handle1 = urllib2.urlopen(req)
+            handle1 = sickbeard.helpers.getURLFileLike(url_loc, throw_exc=True)
             response1 = handle1.read()
             xml = parseString(response1)
             time.sleep (300.0 / 1000.0)
@@ -65,8 +61,7 @@ class NMJv2Notifier:
                 xmlTag=node.toxml();
                 xmlData=xmlTag.replace('<path>','').replace('</path>','').replace('[=]','')
                 url_db = "http://" + host + ":8008/metadata_database?arg0=check_database&arg1="+ xmlData
-                reqdb = urllib2.Request(url_db)
-                handledb = urllib2.urlopen(reqdb)
+                handledb = sickbeard.helpers.getURLFileLike(url_db, throw_exc=True)
                 responsedb = handledb.read()
                 xmldb = parseString(responsedb)
                 returnvalue=xmldb.getElementsByTagName('returnValue')[0].toxml().replace('<returnValue>','').replace('</returnValue>','')
@@ -103,12 +98,10 @@ class NMJv2Notifier:
             logger.log(u"NMJ scan update command send to host: %s" % (host))
             url_updatedb = "http://" + host + ":8008/metadata_database?arg0=scanner_start&arg1="+ sickbeard.NMJv2_DATABASE +"&arg2=background&arg3="
             logger.log(u"Try to mount network drive via url: %s" % (host), logger.DEBUG)
-            prereq = urllib2.Request(url_scandir)
-            req = urllib2.Request(url_updatedb)
-            handle1 = urllib2.urlopen(prereq)
+            handle1 = sickbeard.helpers.getURLFileLike(url_scandir, throw_exc=True)
             response1 = handle1.read()
             time.sleep (300.0 / 1000.0)
-            handle2 = urllib2.urlopen(req)
+            handle2 = sickbeard.helpers.getURLFileLike(url_updatedb, throw_exc=True)
             response2 = handle2.read()
         except IOError, e:
             logger.log(u"Warning: Couldn't contact popcorn hour on host %s: %s" % (host, e))
@@ -117,8 +110,8 @@ class NMJv2Notifier:
             et = etree.fromstring(response1)
             result1 = et.findtext("returnValue")
         except SyntaxError, e:
-             logger.log(u"Unable to parse XML returned from the Popcorn Hour: update_scandir, %s" % (e), logger.ERROR)
-             return False
+            logger.log(u"Unable to parse XML returned from the Popcorn Hour: update_scandir, %s" % (e), logger.ERROR)
+            return False
         try:            
             et = etree.fromstring(response2)
             result2 = et.findtext("returnValue")

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -18,7 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2
+from urllib import urlencode
+from urllib2 import Request, URLError
 import time
 
 import sickbeard
@@ -53,7 +54,7 @@ class PushoverNotifier:
         msg = msg.strip()
         curUrl = API_URL
 
-        data = urllib.urlencode({
+        data = urlencode({
             'token': API_KEY,
             'title': title,
             'user': userKey,
@@ -64,11 +65,11 @@ class PushoverNotifier:
 
         # send the request to pushover
         try:
-            req = urllib2.Request(curUrl)
-            handle = urllib2.urlopen(req, data)
+            req = Request(curUrl, data)
+            handle = sickbeard.helpers.getURLFileLike(req, throw_exc=True)
             handle.close()
             
-        except urllib2.URLError, e:
+        except URLError, e:
             # if we get an error back that doesn't have an error code then who knows what's really happening
             if not hasattr(e, 'code'):
                 logger.log("Pushover notification failed." + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/pytivo.py
+++ b/sickbeard/notifiers/pytivo.py
@@ -20,7 +20,7 @@ import os
 import sickbeard
 
 from urllib import urlencode
-from urllib2 import Request, urlopen, URLError
+from urllib2 import URLError
 
 from sickbeard import logger
 from sickbeard import encodingKludge as ek
@@ -44,11 +44,11 @@ class pyTivoNotifier:
         shareName = sickbeard.PYTIVO_SHARE_NAME
         tsn = sickbeard.PYTIVO_TIVO_NAME
         
-        # There are two more values required, the container and file.
+        # There are two more values required, the container and libraryFile.
         # 
         # container: The share name, show name and season
         #
-        # file: The file name
+        # libraryFile: The libraryFile name
         # 
         # Some slicing and dicing of variables is required to get at these values.
         #
@@ -72,17 +72,15 @@ class pyTivoNotifier:
         showAndSeason = rootShowAndSeason.replace(root, "")
         
         container = shareName + "/" + showAndSeason
-        file = "/" + absPath.replace(root, "")
+        libraryFile = "/" + absPath.replace(root, "")
         
-        # Finally create the url and make request
-        requestUrl = "http://" + host + "/TiVoConnect?" + urlencode( {'Command':'Push', 'Container':container, 'File':file, 'tsn':tsn} )
+        # Finally create the url and retrieve its contents
+        requestUrl = "http://" + host + "/TiVoConnect?" + urlencode( {'Command':'Push', 'Container':container, 'File':libraryFile, 'tsn':tsn} )
                
         logger.log(u"pyTivo notification: Requesting " + requestUrl)
-        
-        request = Request( requestUrl )
 
         try:
-            response = urlopen(request) #@UnusedVariable   
+            sickbeard.helpers.getURLFileLike(requestUrl, throw_exc=True)
         except URLError, e:
             if hasattr(e, 'reason'):
                 logger.log(u"pyTivo notification: Error, failed to reach a server")

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -17,8 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import urllib2
-
+from urllib2 import Request
 from hashlib import sha1
 
 try:
@@ -133,7 +132,8 @@ class TraktNotifier:
         # request the URL from trakt and parse the result as json
         try:
             logger.log("trakt_notifier: Calling method http://api.trakt.tv/" + method + ", with data" + encoded_data, logger.DEBUG)
-            stream = urllib2.urlopen("http://api.trakt.tv/" + method, encoded_data)
+            req = Request("http://api.trakt.tv/" + method, data=encoded_data)
+            stream = sickbeard.helpers.getURLFileLike(req, throw_exc=True)
             resp = stream.read()
 
             resp = json.loads(resp)

--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -18,9 +18,10 @@
 
 from __future__ import with_statement
 
-import urllib2
-import xml.etree.cElementTree as etree
-import xml.etree
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree
 import re
 
 from name_parser.parser import NameParser, InvalidNameException
@@ -34,7 +35,7 @@ from sickbeard.exceptions import ex
 def getSeasonNZBs(name, urlData, season):
 
     try:
-        showXML = etree.ElementTree(etree.XML(urlData))
+        showXML = ElementTree(ElementTree.XML(urlData))
     except SyntaxError:
         logger.log(u"Unable to parse the XML of " + name + ", not splitting it", logger.ERROR)
         return ({}, '')
@@ -79,14 +80,14 @@ def getSeasonNZBs(name, urlData, season):
 
 def createNZBString(fileElements, xmlns):
 
-    rootElement = etree.Element("nzb")
+    rootElement = ElementTree.Element("nzb")
     if xmlns:
         rootElement.set("xmlns", xmlns)
 
     for curFile in fileElements:
         rootElement.append(stripNS(curFile, xmlns))
 
-    return xml.etree.ElementTree.tostring(rootElement, 'utf-8')
+    return ElementTree.tostring(rootElement, 'utf-8')
 
 
 def saveNZB(nzbName, nzbString):

--- a/sickbeard/providers/bithdtv.py
+++ b/sickbeard/providers/bithdtv.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -138,10 +135,10 @@ class BitHDTVProvider(generic.TorrentProvider):
         search_params = search_params.replace(" ","+")
         
         logger.log("[" + self.name + "] Searching TV Section")
-        self.parseResults(self.url + "torrents.php?search=" + urllib.quote(search_params) + "&cat=10")
+        self.parseResults(self.url + "torrents.php?search=" + quote(search_params) + "&cat=10")
         
         logger.log("[" + self.name + "] Searching TV Pack Section")
-        self.parseResults(self.url + "torrents.php?search=" + urllib.quote(search_params) + "&cat=12")
+        self.parseResults(self.url + "torrents.php?search=" + quote(search_params) + "&cat=12")
         
         if len(self.search_results):
             logger.log("[" + self.name + "] parseResults() Some results found.")
@@ -169,7 +166,7 @@ class BitHDTVProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -237,7 +234,7 @@ class BitHDTVCache(tvcache.TVCache):
                 "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
         for title, url in provider.search_results:
-            xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>" + urllib.quote(url,'/,:?') + "</link>" + "</item>"
+            xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>" + quote(url,'/,:?') + "</link>" + "</item>"
         xml += "</channel> </rss>"
         return xml
         

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -18,21 +18,16 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import re
-import urllib, urllib2, cookielib
+from urllib2 import HTTPError
 import sys
 import datetime
-import os
-import exceptions
 import sickbeard
 import generic
 import json
 
 from operator import itemgetter
-from xml.sax.saxutils import escape
 from sickbeard.common import Quality
 from sickbeard import logger
-from sickbeard import tvcache
 from sickbeard import helpers
 from sickbeard import show_name_helpers
 from sickbeard import db
@@ -177,8 +172,8 @@ class BTDIGGProvider(generic.TorrentProvider):
         logger.log("[BTDigg] Requesting - " + url)
         try:
             #response = helpers.getURL(url, headers)
-            response = urllib.urlopen(url)
-        except (urllib2.HTTPError, IOError, Exception), e:
+            response = helpers.getURLFileLike(url, throw_exc=True)
+        except (HTTPError, IOError, Exception), e:
             logger.log("[BTDigg] getURL() Error loading " + self.name + " URL: " + str(sys.exc_info()) + " - " + ex(e), logger.ERROR)
             return None
         return response

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -25,7 +25,6 @@ from sickbeard import scene_exceptions
 from sickbeard import logger
 from sickbeard import tvcache
 from sickbeard.helpers import sanitizeSceneName
-from sickbeard.common import Quality
 from sickbeard.exceptions import ex, AuthException
 
 from lib import jsonrpclib
@@ -118,7 +117,7 @@ class BTNProvider(generic.TorrentProvider):
 
             results = []
 
-            for torrentid, torrent_info in found_torrents.iteritems():
+            for dummy, torrent_info in found_torrents.iteritems():
                 (title, url) = self._get_title_and_url(torrent_info)
 
                 if title and url:

--- a/sickbeard/providers/ezrss.py
+++ b/sickbeard/providers/ezrss.py
@@ -16,13 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from urllib import urlencode
 import re
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree
-
 import sickbeard
 import generic
 
@@ -107,7 +102,7 @@ class EZRSSProvider(generic.TorrentProvider):
         if search_params:
             params.update(search_params)
 
-        search_url = self.url + 'search/index.php?' + urllib.urlencode(params)
+        search_url = self.url + 'search/index.php?' + urlencode(params)
 
         logger.log(u"Search string: " + search_url, logger.DEBUG)
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -21,7 +21,7 @@ from __future__ import with_statement
 import datetime
 import os
 import re
-
+from urllib2 import Request
 import sickbeard
 
 from sickbeard import helpers, classes, logger, db
@@ -95,22 +95,27 @@ class GenericProvider:
 
         return result
 
-    def getURL(self, url, post_data=None, headers=None):
+    def getURL(self, url, post_data=None, heads=None):
         """
         By default this is just a simple urlopen call but this method should be overridden
         for providers with special URL requirements (like cookies)
         """
+        if post_data:
+            if heads:
+                req = Request(url, post_data, heads)
+            else:
+                req = Request(url, post_data);
+        else:
+            if heads:
+                req = Request(url, headers=heads);
+            else:
+                req = Request(url);
+        response = helpers.getURL(req)
 
-        if not headers:
-            headers = []
-        
-        data = helpers.getURL(url, post_data, headers)
-
-        if not data:
+        if response is None:
             logger.log(u"Error loading " + self.name + " URL: " + url, logger.ERROR)
-            return None
 
-        return data
+        return response
 
     def downloadResult(self, result):
         """

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -13,14 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from urllib import urlencode
 import generic
 import sickbeard
 
 from sickbeard import logger, tvcache, exceptions
 from sickbeard import helpers
 from sickbeard.common import Quality
-from sickbeard.exceptions import ex, AuthException
+from sickbeard.exceptions import AuthException
 from sickbeard.name_parser.parser import NameParser, InvalidNameException
 
 try:
@@ -141,7 +141,7 @@ class HDBitsProvider(generic.TorrentProvider):
     def _get_title_and_url(self, item):
 
         title = item['name']
-        url = self.download_url + urllib.urlencode({'id': item['id'], 'passkey': sickbeard.HDBITS_PASSKEY})
+        url = self.download_url + urlencode({'id': item['id'], 'passkey': sickbeard.HDBITS_PASSKEY})
 
         return (title, url)
 

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -33,7 +30,6 @@ from xml.sax.saxutils import escape
 from sickbeard.common import Quality
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import helpers
 from sickbeard import show_name_helpers
 from sickbeard import db
 from sickbeard.common import Overview
@@ -130,7 +126,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
 
     def _doSearch(self, search_params, show=None):
         logger.log("[IPTorrents] Performing Search: {0}".format(search_params))
-        searchUrl = self.url + "torrents/?l78=&l79=&l5=&q=" + urllib.quote(search_params)
+        searchUrl = self.url + "torrents/?l78=&l79=&l5=&q=" + quote(search_params)
         return self.parseResults(searchUrl)
     
     ################################################################################################### 
@@ -161,7 +157,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -234,7 +230,7 @@ class IPTorrentsCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
             for title, url in data:
-                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml
 

--- a/sickbeard/providers/kickass.py
+++ b/sickbeard/providers/kickass.py
@@ -18,15 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
-import re
-import sys
 import json
-import urllib
+from urllib import urlencode
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -155,14 +151,14 @@ class KickAssProvider(generic.TorrentProvider):
             else:
                 SearchParameters["field"] = "time_add"
             
-            SearchQuery = urllib.urlencode(SearchParameters)
+            SearchQuery = urlencode(SearchParameters)
             
             searchData = self.getURL(self.url + "json.php?%s" % SearchQuery )
               
             if searchData:
                 try:
                     jdata = json.loads(searchData)
-                except ValueError, e:
+                except ValueError:
                     logger.log("[" + self.name + "] _doSearch() invalid data on search page " + str(page))
                     continue
                 

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -16,16 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from urllib import urlencode
 import email.utils
 import datetime
 import re
 import os
-
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree
 
 import sickbeard
 import generic
@@ -37,7 +32,7 @@ from sickbeard import encodingKludge as ek
 
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard.exceptions import ex, AuthException
+from sickbeard.exceptions import AuthException
 
 
 class NewznabProvider(generic.NZBProvider):
@@ -208,7 +203,7 @@ class NewznabProvider(generic.NZBProvider):
         if self.needs_auth and self.key:
             params['apikey'] = self.key
 
-        search_url = self.url + 'api?' + urllib.urlencode(params)
+        search_url = self.url + 'api?' + urlencode(params)
 
         logger.log(u"Search url: " + search_url, logger.DEBUG)
 
@@ -306,7 +301,7 @@ class NewznabCache(tvcache.TVCache):
         if self.provider.needs_auth and self.provider.key:
             params['apikey'] = self.provider.key
 
-        rss_url = self.provider.url + 'api?' + urllib.urlencode(params)
+        rss_url = self.provider.url + 'api?' + urlencode(params)
 
         logger.log(self.provider.name + " cache update URL: " + rss_url, logger.DEBUG)
 

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from urllib import urlencode
 import generic
 import sickbeard
 
@@ -24,19 +24,9 @@ from sickbeard import tvcache
 from sickbeard import helpers
 from sickbeard import classes
 from sickbeard import logger
-from sickbeard.exceptions import ex, AuthException
+from sickbeard.exceptions import AuthException
 from sickbeard import show_name_helpers
 from datetime import datetime
-
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree
-
-try:
-    import json
-except ImportError:
-    from lib import simplejson as json
 
 
 class OmgwtfnzbsProvider(generic.NZBProvider):
@@ -108,7 +98,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         if retention or not params['retention']:
             params['retention'] = retention
 
-        search_url = 'https://api.omgwtfnzbs.org/json/?' + urllib.urlencode(params)
+        search_url = 'https://api.omgwtfnzbs.org/json/?' + urlencode(params)
         logger.log(u"Search url: " + search_url, logger.DEBUG)
 
         data = self.getURL(search_url)
@@ -167,7 +157,7 @@ class OmgwtfnzbsCache(tvcache.TVCache):
                   'eng': 1,
                   'catid': '19,20'}  # SD,HD
 
-        rss_url = 'https://rss.omgwtfnzbs.org/rss-download.php?' + urllib.urlencode(params)
+        rss_url = 'https://rss.omgwtfnzbs.org/rss-download.php?' + urlencode(params)
 
         logger.log(self.provider.name + u" cache update URL: " + rss_url, logger.DEBUG)
 

--- a/sickbeard/providers/revolutiontt.py
+++ b/sickbeard/providers/revolutiontt.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -136,7 +133,7 @@ class RevolutionTTProvider(generic.TorrentProvider):
         results=[]
         logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
         for section in [41,42,45]:
-            searchUrl = self.url + "browse.php?search=" + urllib.quote(search_params) + "&cat=" + str(section) + "&titleonly=1"
+            searchUrl = self.url + "browse.php?search=" + quote(search_params) + "&cat=" + str(section) + "&titleonly=1"
             results.extend(self.parseResults(searchUrl))
         if len(results):
             logger.log("[" + self.name + "] parseResults() Some results found.")
@@ -163,7 +160,7 @@ class RevolutionTTProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
                        
         try:
@@ -234,7 +231,7 @@ class RevolutionTTCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
             for title, url in data:
-                xml += "<item>" + "<title>" + escape(title.decode('utf8','ignore')) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title.decode('utf8','ignore')) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml
         

--- a/sickbeard/providers/sceneaccess.py
+++ b/sickbeard/providers/sceneaccess.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -134,7 +131,7 @@ class SceneAccessProvider(generic.TorrentProvider):
 
     def _doSearch(self, search_params, show=None):
         logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
-        searchUrl = self.url + "browse?search=" + urllib.quote(search_params) + "&method=2&c27=27&c17=17&c11=11"
+        searchUrl = self.url + "browse?search=" + quote(search_params) + "&method=2&c27=27&c17=17&c11=11"
         return self.parseResults(searchUrl)
     
     ################################################################################################### 
@@ -160,7 +157,7 @@ class SceneAccessProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -233,7 +230,7 @@ class SceneAccessCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
             for title, url in data:
-                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml
         

--- a/sickbeard/providers/speed.py
+++ b/sickbeard/providers/speed.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -133,7 +130,7 @@ class SpeedProvider(generic.TorrentProvider):
 
     def _doSearch(self, search_params, show=None):
         logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
-        searchUrl = self.url + "browse.php?c49=1&c2=1&c41=1&search=" + urllib.quote(search_params)
+        searchUrl = self.url + "browse.php?c49=1&c2=1&c41=1&search=" + quote(search_params)
         return self.parseResults(searchUrl)
     
     ################################################################################################### 
@@ -159,7 +156,7 @@ class SpeedProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -232,7 +229,7 @@ class SpeedCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
             
             for title, url in data:
-                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml
         

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -21,7 +21,8 @@
 ###################################################################################################
 
 import re
-import urllib, urllib2
+from urllib import quote, unquote
+from urllib2 import HTTPError
 import sys
 import datetime
 import os
@@ -150,7 +151,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
     ###################################################################################################
     def _doSearch(self, search_params, show=None):
         results = []
-        searchURL = self.proxy._buildURL(self.searchurl %(urllib.quote(search_params)))    
+        searchURL = self.proxy._buildURL(self.searchurl %(quote(search_params)))    
         logger.log(u"Search string: " + searchURL, logger.DEBUG)
                     
         data = self.getURL(searchURL)
@@ -160,7 +161,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
         re_title_url = self.proxy._buildRE(self.re_title_url)
         
         #Extracting torrent information from searchURL                   
-        match = re.compile(re_title_url, re.DOTALL ).finditer(urllib.unquote(data))
+        match = re.compile(re_title_url, re.DOTALL ).finditer(unquote(data))
         for torrent in match:
             #Accept Torrent only from Good People
             if sickbeard.THEPIRATEBAY_TRUSTED and re.search('(VIP|Trusted|Helpers)',torrent.group(0))== None:
@@ -193,7 +194,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         try:
             result = helpers.getURL(url, headers=headers)
-        except (urllib2.HTTPError, IOError), e:
+        except (HTTPError, IOError), e:
             logger.log(u"Error loading "+self.name+" URL: " + str(sys.exc_info()) + " - " + ex(e), logger.ERROR)
             return None
 
@@ -242,7 +243,7 @@ class ThePirateBayCache(tvcache.TVCache):
         # now that we've loaded the current RSS feed lets delete the old cache
         logger.log(u"Clearing "+self.provider.name+" cache and updating with new information")
         self._clearCache()
-        match = re.compile(re_title_url, re.DOTALL).finditer(urllib.unquote(data))
+        match = re.compile(re_title_url, re.DOTALL).finditer(unquote(data))
         if not match:
             logger.log(u"The Data returned from the ThePirateBay is incomplete, this result is unusable", logger.ERROR)
             return []

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -18,18 +18,13 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
 import json
-import urllib
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
-from xml.sax.saxutils import escape
 
 from sickbeard import db
 from sickbeard import logger
@@ -148,7 +143,7 @@ class TorrentDayProvider(generic.TorrentProvider):
                 logger.log("[" + self.name + "] _doSearch() search data sent 0 results.")
                 return []
             torrents = jdata.get('Fs', [])[0].get('Cn', {}).get('torrents', [])
-        except ValueError, e:
+        except ValueError:
             logger.log("[" + self.name + "] _doSearch() invalid json returned.")
             return []
 

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -42,13 +39,13 @@ class TorrentLeechProvider(generic.TorrentProvider):
 
     ###################################################################################################
     def __init__(self):
-	generic.TorrentProvider.__init__(self, "TorrentLeech")
-	self.cache = TorrentLeechCache(self)     
-	self.name = "TorrentLeech"
-	self.session = None
-	self.supportsBacklog = True
-	self.url = 'http://www.torrentleech.org/'
-	logger.log("[" + self.name + "] initializing...")
+        generic.TorrentProvider.__init__(self, "TorrentLeech")
+        self.cache = TorrentLeechCache(self)     
+        self.name = "TorrentLeech"
+        self.session = None
+        self.supportsBacklog = True
+        self.url = 'http://www.torrentleech.org/'
+        logger.log("[" + self.name + "] initializing...")
         
     ###################################################################################################
     
@@ -132,23 +129,23 @@ class TorrentLeechProvider(generic.TorrentProvider):
     ###################################################################################################
 
     def _doSearch(self, search_params, show=None):
-	logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
-	searchUrl = self.url + "torrents/browse/index/query/" + search_params.replace(':','') + "/categories/26,27,32"
-	return self.parseResults(searchUrl)
+        logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
+        searchUrl = self.url + "torrents/browse/index/query/" + search_params.replace(':','') + "/categories/26,27,32"
+        return self.parseResults(searchUrl)
     
     ##################################################################################################
     
     def parseResults(self, searchUrl):
-	data = self.getURL(searchUrl)
-	results = []
-	
-	if data:
+        data = self.getURL(searchUrl)
+        results = []        
+        
+        if data:
             logger.log("[" + self.name + "] parseResults() URL: " + searchUrl, logger.DEBUG)
-	    
-	    for torrent in re.compile('<span class="title"><a href="/torrent/\d+">(?P<title>.*?)</a>.*?<td class="quickdownload">\s+<a href="/(?P<url>.*?)">',re.MULTILINE|re.DOTALL).finditer(data):
-		item = (torrent.group('title').replace('.',' '), self.url + torrent.group('url'))
-                results.append(item)                        
-                logger.log("[" + self.name + "] parseResults() Title: " + torrent.group('title'), logger.DEBUG)
+            
+        for torrent in re.compile('<span class="title"><a href="/torrent/\d+">(?P<title>.*?)</a>.*?<td class="quickdownload">\s+<a href="/(?P<url>.*?)">',re.MULTILINE|re.DOTALL).finditer(data):
+            item = (torrent.group('title').replace('.',' '), self.url + torrent.group('url'))
+            results.append(item)                        
+            logger.log("[" + self.name + "] parseResults() Title: " + torrent.group('title'), logger.DEBUG)
             if len(results):
                 logger.log("[" + self.name + "] parseResults() Some results found.")
             else:
@@ -163,7 +160,7 @@ class TorrentLeechProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -216,24 +213,24 @@ class TorrentLeechCache(tvcache.TVCache):
         tvcache.TVCache.__init__(self, provider)
         # only poll TorrentLeech every 15 minutes max
         self.minTime = 15
-	
+
     ###################################################################################################
     
     def _getRSSData(self):
-	# TorrentLeech's RSS sucks.. its all or nothing... so manual reconstruction required for just tv sections...
-	xml = "<rss xmlns:atom=\"http://www.w3.org/2005/Atom\" version=\"2.0\">" + \
-	    "<channel>" + \
-	    "<title>" + provider.name + "</title>" + \
-	    "<link>" + provider.url + "</link>" + \
-	    "<description>torrent search</description>" + \
-	    "<language>en-us</language>" + \
-	    "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
-	
-	for title, url in provider._doSearch(""):
-	    xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
-	xml += "</channel> </rss>"
-	return xml
-	
-	###################################################################################################
-	
+        # TorrentLeech's RSS sucks.. its all or nothing... so manual reconstruction required for just tv sections...
+        xml = "<rss xmlns:atom=\"http://www.w3.org/2005/Atom\" version=\"2.0\">" + \
+    	    "<channel>" + \
+    	    "<title>" + provider.name + "</title>" + \
+    	    "<link>" + provider.url + "</link>" + \
+    	    "<description>torrent search</description>" + \
+    	    "<language>en-us</language>" + \
+    	    "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
+
+        for title, url in provider._doSearch(""):
+            xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
+            xml += "</channel> </rss>"
+            return xml
+
+    ###################################################################################################
+
 provider = TorrentLeechProvider()

--- a/sickbeard/providers/torrentshack.py
+++ b/sickbeard/providers/torrentshack.py
@@ -18,14 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
 import re
-import sys
-import urllib
+from urllib import quote
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -134,7 +131,7 @@ class TorrentShackProvider(generic.TorrentProvider):
     def _doSearch(self, search_params, show=None):
         search_params = search_params.replace('.',' ')
         logger.log("[" + self.name + "] Performing Search: {0}".format(search_params))
-        searchUrl = self.url + "torrents.php?searchstr=" + urllib.quote(search_params) + "&filter_cat[600]=1&filter_cat[620]=1&filter_cat[700]=1&filter_cat[980]=1&filter_cat[981]=1"
+        searchUrl = self.url + "torrents.php?searchstr=" + quote(search_params) + "&filter_cat[600]=1&filter_cat[620]=1&filter_cat[700]=1&filter_cat[980]=1&filter_cat[981]=1"
         return self.parseResults(searchUrl)
     
     ################################################################################################### 
@@ -164,7 +161,7 @@ class TorrentShackProvider(generic.TorrentProvider):
         response = None
         
         if not self.session:
-             if not self._doLogin():
+            if not self._doLogin():
                 return response
             
         if not headers:
@@ -235,7 +232,7 @@ class TorrentShackCache(tvcache.TVCache):
             "<atom:link href=\"" + provider.url + "\" rel=\"self\" type=\"application/rss+xml\"/>"
 
             for title, url in provider._doSearch(""):
-                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ urllib.quote(url,'/,:') + "</link>" + "</item>"
+                xml += "<item>" + "<title>" + escape(title) + "</title>" +  "<link>"+ quote(url,'/,:') + "</link>" + "</item>"
             xml += "</channel></rss>"
         return xml    
         

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -16,20 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-
-
-import traceback
-import urllib
-import urllib2
 import re
-
-import xml.etree.cElementTree as etree
-
+import traceback
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    from xml.etree import ElementTree
 import sickbeard
 import generic
 
-from sickbeard import encodingKludge as ek
-from sickbeard.common import *
 from sickbeard import logger, helpers
 from sickbeard import tvcache
 from sickbeard.helpers import sanitizeSceneName
@@ -115,7 +110,7 @@ class TORRENTZProvider(generic.TorrentProvider):
                     data = self.getURL(searchURL + "&p=%(page)d" % {'page': index })
 
                     if data and data.startswith("<?xml"):
-                        responseSoup = etree.ElementTree(etree.XML(data))
+                        responseSoup = ElementTree(ElementTree.XML(data))
                         newItems = responseSoup.getiterator('item')
                         oldCount = len(items)
                         items.extend(newItems)

--- a/sickbeard/providers/tvtorrents.py
+++ b/sickbeard/providers/tvtorrents.py
@@ -15,16 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
-
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree
-
 import sickbeard
 import generic
 
-from sickbeard.exceptions import ex, AuthException
+from sickbeard.exceptions import AuthException
 from sickbeard import helpers
 from sickbeard import logger
 from sickbeard import tvcache

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -150,7 +150,7 @@ def _checkSabResponse(f):
 
 def _sabURLOpenSimple(url):
     try:
-        f = helpers.getURLFileLike(url)
+        f = helpers.getURLFileLike(url, throw_exc=True)
     except (EOFError, IOError), e:
         logger.log(u"Unable to connect to SAB: " + ex(e), logger.ERROR)
         return False, "Unable to connect"

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -40,8 +40,6 @@ from sickbeard.exceptions import ex
 from sickbeard.providers.generic import GenericProvider
 
 
-import urllib2
-
 def _downloadResult(result):
     """
     Downloads a result to the appropriate black hole folder.
@@ -125,7 +123,7 @@ def snatchEpisode(result, endStatus=SNATCHED):
             allUrls = result.url.split(";", 3)
             for url in allUrls:
                 try:
-                    urllib2.urlopen(url)
+                    helpers.getURLFileLike(url, throw_exc=True)
                     result.url = url
                     break
                 except Exception:

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -29,12 +29,6 @@ from sickbeard.common import Quality
 from sickbeard import helpers, show_name_helpers
 from sickbeard import name_cache
 from sickbeard.exceptions import ex, AuthException
-
-try:
-    import xml.etree.cElementTree as etree
-except ImportError:
-    import elementtree.ElementTree as etree
-
 from lib.tvdb_api import tvdb_api, tvdb_exceptions
 
 from name_parser.parser import NameParser, InvalidNameException

--- a/sickbeard/tvrage.py
+++ b/sickbeard/tvrage.py
@@ -16,8 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
-import urllib2
+from urllib import urlencode
 import datetime
 import traceback
 
@@ -242,7 +241,7 @@ class TVRage:
             urlData['ep'] = str(season) + 'x' + str(episode)
 
         # build the URL
-        url += urllib.urlencode(urlData)
+        url += urlencode(urlData)
 
         logger.log(u"Loading TVRage info from URL: " + url, logger.DEBUG)
         result = helpers.getURL(url)


### PR DESCRIPTION
This should be the PR that replaces #242. 

Maybe you have a reason for it, but wouldn't it be better if the junalmeida/torrentProviders branch wasn't behind the junalmeida/torrent_1080_subtitles branch? It seems to me like the "development" branch (torrentProviders) should always be ahead of, or even with the stable branch (torrent_1080_subtitles). Anyway, just a suggestion. The earlier PR really did turn into a mess, which was my fault. I hope this one is better, I also included a minor fix in helpers.py.
