### PR TITLE
Sanitize Kickass URL

### DIFF
--- a/sickbeard/providers/kickass.py
+++ b/sickbeard/providers/kickass.py
@@ -18,15 +18,11 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################################################################
 
-import os
-import re
-import sys
 import json
 import urllib
 import generic
 import datetime
 import sickbeard
-import exceptions
 
 from lib import requests
 from xml.sax.saxutils import escape
@@ -162,7 +158,7 @@ class KickAssProvider(generic.TorrentProvider):
             if searchData:
                 try:
                     jdata = json.loads(searchData)
-                except ValueError, e:
+                except ValueError:
                     logger.log("[" + self.name + "] _doSearch() invalid data on search page " + str(page))
                     continue
                 

--- a/sickbeard/providers/kickass.py
+++ b/sickbeard/providers/kickass.py
@@ -20,6 +20,7 @@
 
 import json
 import urllib
+from urlparse import urlsplit, urlunsplit
 import generic
 import datetime
 import sickbeard
@@ -44,7 +45,7 @@ class KickAssProvider(generic.TorrentProvider):
         self.name = "KickAss"
         self.session = None
         self.supportsBacklog = True
-        self.url = "http://kickass.to/"
+        self.url = "kat.cr"
         logger.log("[" + self.name + "] initializing...")
         
     ###################################################################################################
@@ -151,10 +152,17 @@ class KickAssProvider(generic.TorrentProvider):
             else:
                 SearchParameters["field"] = "time_add"
             
-            SearchQuery = urllib.urlencode(SearchParameters)
-            
-            searchData = self.getURL(self.url + "json.php?%s" % SearchQuery )
-              
+            # Make sure the URL is correctly formatted by parsing it (defaults to using https URLs)
+            scheme, netloc, path, query, fragment = urlsplit(self.url, scheme="https")
+            # Make sure netloc is available, without a scheme in the parsed string it is 
+            # recognized as path without a netloc
+            if not netloc:
+                netloc = path
+            path = "json.php"
+            query = urllib.urlencode(SearchParameters)
+            searchURL = urlunsplit((scheme, netloc, path, query, fragment))
+            searchData = self.getURL(searchURL)
+
             if searchData:
                 try:
                     jdata = json.loads(searchData)


### PR DESCRIPTION
Minor change that ensures that the Kickass URL is always in the correct format. This is useful since users can provide their own alternative URL, which might not always work if it's not properly formatted (e.g. when you forget the trailing slash). 

This change parses the url string and formats it appropriately. If no scheme is provided in the url string, the url string is considered to be the hostname. The default python behavior here is to consider it a relative url without hostname, but that would make no sense for sickbeard or kickass. The default scheme used is "https".

Also updated kickass URL to latest domain.