### PR TITLE
Avoid early junk/spam/fakes

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -39,6 +39,14 @@
                         </div>
                             
                         <div class="field-pair">
+                            <input type="checkbox" name="download_avoid_junk" id="download_avoid_junk" #if $sickbeard.DOWNLOAD_AVOID_JUNK == True then "checked=\"checked\"" else ""# />
+                            <label class="clearfix" for="download_avoid_junk">
+                                <span class="component-title">Avoid Junk Downloads</span>
+                                <span class="component-desc">Wait until the day after an episode airs to download it in an attempt to avoid junk downloads?</span>
+                            </label>
+                        </div>
+                            
+                        <div class="field-pair">
                             <input type="checkbox" name="download_propers" id="download_propers" #if $sickbeard.DOWNLOAD_PROPERS == True then "checked=\"checked\"" else ""# />
                             <label class="clearfix" for="download_propers">
                                 <span class="component-title">Download Propers</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -161,6 +161,7 @@ NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
+DOWNLOAD_AVOID_JUNK = None
 PREFER_EPISODE_RELEASES = None
 
 SEARCH_FREQUENCY = None
@@ -389,7 +390,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR,TORRENT_METHOD, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR,TORRENT_METHOD, DOWNLOAD_PROPERS, DOWNLOAD_AVOID_JUNK, PREFER_EPISODE_RELEASES, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_RATIO, TORRENT_PAUSED, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
@@ -540,6 +541,7 @@ def initialize(consoleLogging=True):
         if TORRENT_METHOD not in ('blackhole', 'utorrent', 'transmission', 'downloadstation', 'deluge'):
             TORRENT_METHOD = 'blackhole'
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        DOWNLOAD_AVOID_JUNK = bool(check_setting_int(CFG, 'General', 'download_avoid_junk', 1))
         PREFER_EPISODE_RELEASES = bool(check_setting_int(CFG, 'General', 'prefer_episode_releases', 0))
 
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
@@ -1152,6 +1154,7 @@ def save_config():
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['download_avoid_junk'] = int(DOWNLOAD_AVOID_JUNK)
     new_config['General']['prefer_episode_releases'] = int(PREFER_EPISODE_RELEASES)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -123,6 +123,7 @@ def processDir (dirName, nzbName=None, recurse=False):
                 returnStr += logHelper(u"Deleting folder " + dirName, logger.DEBUG)
 
                 try:
+                    os.chmod(dirName, stat.S_IWRITE) # make sure folder is not read-only to allow for delete on Windows
                     shutil.rmtree(dirName)
                 except (OSError, IOError), e:
                     returnStr += logHelper(u"Warning: unable to remove the folder " + dirName + ": " + ex(e), logger.WARNING)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -769,6 +769,7 @@ class ConfigSearch:
 
         # Episode Search
         sickbeard.DOWNLOAD_PROPERS = config.checkbox_to_value(postData.get("download_propers"))
+        sickbeard.DOWNLOAD_AVOID_JUNK = config.checkbox_to_value(postData.get("download_avoid_junk"))
 
         if sickbeard.DOWNLOAD_PROPERS:
             sickbeard.properFinderScheduler.silent = False


### PR DESCRIPTION
Added option to wait until the day after an episode airs to download it in an attempt to avoid early junk/spam/fake downloads.

Also added chmod to make sure path for cleanup is not read-only so rmtree doesn't fail (frequent issue on Windows).