### PR TITLE
Added the ability to filter torrents if they do not have enough seeders

### DIFF
--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -57,7 +57,7 @@
                         <div class="field-pair">
                             <label class="nocheck clearfix">
                                 <span class="component-title">Minimum Seeders</span>
-                                <input type="number" name="minimum_seeders" value="$sickbeard.MIN_SEEDERS" size="5" min="10" class="input-small" />
+                                <input type="number" name="minimum_seeders" value="$sickbeard.MIN_SEEDERS" size="5" min="0" class="input-small" />
                             </label>
                             <label class="nocheck clearfix">
                                 <span class="component-title">&nbsp;</span>

--- a/data/interfaces/default/config_search.tmpl
+++ b/data/interfaces/default/config_search.tmpl
@@ -53,6 +53,17 @@
                                 <span class="component-desc">Ignore full season releases.</span>
                             </label>
                         </div>
+
+                        <div class="field-pair">
+                            <label class="nocheck clearfix">
+                                <span class="component-title">Minimum Seeders</span>
+                                <input type="number" name="minimum_seeders" value="$sickbeard.MIN_SEEDERS" size="5" min="10" class="input-small" />
+                            </label>
+                            <label class="nocheck clearfix">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">Minimum number of seeders required for a torrent to be added</span>
+                            </label>
+                        </div>
                                                 
                         <div class="field-pair">
                             <label class="nocheck clearfix">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -161,6 +161,7 @@ NZB_METHOD = None
 NZB_DIR = None
 USENET_RETENTION = None
 DOWNLOAD_PROPERS = None
+MIN_SEEDERS = None
 PREFER_EPISODE_RELEASES = None
 
 SEARCH_FREQUENCY = None
@@ -390,7 +391,7 @@ def initialize(consoleLogging=True):
     with INIT_LOCK:
 
         global ACTUAL_LOG_DIR, LOG_DIR, WEB_PORT, WEB_LOG, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, USE_API, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR,TORRENT_METHOD, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, \
+                USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR,TORRENT_METHOD, DOWNLOAD_PROPERS, PREFER_EPISODE_RELEASES, MIN_SEEDERS, \
                 SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_HOST, \
                 TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_LABEL, TORRENT_HOST, TORRENT_PATH, TORRENT_RATIO, TORRENT_PAUSED, \
                 NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_HOST, currentSearchScheduler, backlogSearchScheduler, \
@@ -541,6 +542,7 @@ def initialize(consoleLogging=True):
         if TORRENT_METHOD not in ('blackhole', 'utorrent', 'transmission', 'downloadstation', 'deluge'):
             TORRENT_METHOD = 'blackhole'
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        MIN_SEEDERS = check_setting_int(CFG, 'General', 'minimum_seeders', 1)
         PREFER_EPISODE_RELEASES = bool(check_setting_int(CFG, 'General', 'prefer_episode_releases', 0))
 
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
@@ -1154,6 +1156,7 @@ def save_config():
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['search_frequency'] = int(SEARCH_FREQUENCY)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['minimum_seeders'] = int(MIN_SEEDERS)
     new_config['General']['prefer_episode_releases'] = int(PREFER_EPISODE_RELEASES)
     new_config['General']['quality_default'] = int(QUALITY_DEFAULT)
     new_config['General']['status_default'] = int(STATUS_DEFAULT)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -17,6 +17,7 @@
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import with_statement
+from _ssl import SSLError
 
 import gzip
 import os
@@ -151,7 +152,7 @@ def getURL(url, post_data=None, headers=[]):
         opener.addheaders.append(cur_header)
 
     try:
-        usock = opener.open(url, post_data)
+        usock = opener.open(url, post_data, timeout=15)
         url = usock.geturl()
         encoding = usock.info().get("Content-Encoding")
 
@@ -186,6 +187,10 @@ def getURL(url, post_data=None, headers=[]):
 
     except ValueError:
         logger.log(u"Unknown error while loading URL " + url, logger.WARNING)
+        return None
+
+    except SSLError, e:
+        logger.log(u"SSL error while loading URL " + e.message, logger.WARNING)
         return None
 
     except Exception:

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -214,9 +214,7 @@ class GenericProvider:
         if url:
             url = url.replace('&amp;', '&')
 
-        seeders = helpers.get_xml_text(item.find('seeders'))
-
-        return (title, url, seeders)
+        return (title, url)
 
     def findEpisode(self, episode, manualSearch=False):
 
@@ -239,7 +237,7 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url, seeders) = self._get_title_and_url(item)
+            (title, url, seeders) = self._get_title_and_url(item)[::3]
 
             # parse the file name
             try:
@@ -265,6 +263,10 @@ class GenericProvider:
                 logger.log(u"Ignoring result " + title + " because we don't want an episode that is " + Quality.qualityStrings[quality], logger.DEBUG)
                 continue
 
+            if seeders and seeders < sickbeard.MIN_SEEDERS:
+                logger.log(u"Ignoring result {0} it doesn't have enough seeders. (Has: {1}, Needs: {2})".format(title, seeders, sickbeard.MIN_SEEDERS))
+                continue
+
             logger.log(u"Found result " + title + " at " + url, logger.DEBUG)
 
             result = self.getResult([episode])
@@ -286,7 +288,7 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url, seeders) = self._get_title_and_url(item)
+            (title, url, seeders) = self._get_title_and_url(item)[::3]
 
             quality = self.getQuality(item)
 
@@ -332,6 +334,10 @@ class GenericProvider:
 
             if not wantEp:
                 logger.log(u"Ignoring result " + title + " because we don't want an episode that is " + Quality.qualityStrings[quality], logger.DEBUG)
+                continue
+
+            if seeders and seeders < sickbeard.MIN_SEEDERS:
+                logger.log(u"Ignoring result {0} it doesn't have enough seeders. (Has: {1}, Needs: {2})".format(title, seeders, sickbeard.MIN_SEEDERS))
                 continue
 
             logger.log(u"Found result " + title + " at " + url, logger.DEBUG)

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -214,7 +214,9 @@ class GenericProvider:
         if url:
             url = url.replace('&amp;', '&')
 
-        return (title, url)
+        seeders = helpers.get_xml_text(item.find('seeders'))
+
+        return (title, url, seeders)
 
     def findEpisode(self, episode, manualSearch=False):
 
@@ -237,7 +239,7 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url) = self._get_title_and_url(item)
+            (title, url, seeders) = self._get_title_and_url(item)
 
             # parse the file name
             try:
@@ -284,7 +286,7 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url) = self._get_title_and_url(item)
+            (title, url, seeders) = self._get_title_and_url(item)
 
             quality = self.getQuality(item)
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -185,7 +185,11 @@ class GenericProvider:
         Returns a Quality value obtained from the node's data
 
         """
-        (title, url) = self._get_title_and_url(item)  # @UnusedVariable
+        torrent_info = self._get_title_and_url(item)
+        if torrent_info.__len__() == 2:
+            (title, url) = torrent_info
+        else:
+            (title, url, seeders) = torrent_info
         quality = Quality.nameQuality(title)
         return quality
 
@@ -237,7 +241,12 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url, seeders) = self._get_title_and_url(item)[::3]
+            seeders = -1
+            torrent_info = self._get_title_and_url(item)
+            if torrent_info.__len__() == 2:
+                (title, url) = torrent_info
+            else:
+                (title, url, seeders) = torrent_info
 
             # parse the file name
             try:
@@ -263,7 +272,9 @@ class GenericProvider:
                 logger.log(u"Ignoring result " + title + " because we don't want an episode that is " + Quality.qualityStrings[quality], logger.DEBUG)
                 continue
 
-            if seeders and seeders < sickbeard.MIN_SEEDERS:
+            if seeders == -1:
+                logger.log(u"{0} doesn't support filtering by minimum seeders at the moment".format(self.name))
+            elif seeders < sickbeard.MIN_SEEDERS:
                 logger.log(u"Ignoring result {0} it doesn't have enough seeders. (Has: {1}, Needs: {2})".format(title, seeders, sickbeard.MIN_SEEDERS))
                 continue
 
@@ -288,7 +299,12 @@ class GenericProvider:
 
         for item in itemList:
 
-            (title, url, seeders) = self._get_title_and_url(item)[::3]
+            seeders = -1
+            torrent_info = self._get_title_and_url(item)
+            if torrent_info.__len__() == 2:
+                (title, url) = torrent_info
+            else:
+                (title, url, seeders) = torrent_info
 
             quality = self.getQuality(item)
 
@@ -336,10 +352,11 @@ class GenericProvider:
                 logger.log(u"Ignoring result " + title + " because we don't want an episode that is " + Quality.qualityStrings[quality], logger.DEBUG)
                 continue
 
-            if seeders and seeders < sickbeard.MIN_SEEDERS:
+            if seeders == -1:
+                logger.log(u"{0} doesn't support filtering by minimum seeders at the moment".format(self.name))
+            elif seeders < sickbeard.MIN_SEEDERS:
                 logger.log(u"Ignoring result {0} it doesn't have enough seeders. (Has: {1}, Needs: {2})".format(title, seeders, sickbeard.MIN_SEEDERS))
                 continue
-
             logger.log(u"Found result " + title + " at " + url, logger.DEBUG)
 
             # make a result object

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -58,7 +58,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
         self.proxy = ThePirateBayWebproxy() 
         self.url = 'http://thepiratebay.se/'
         self.searchurl =  self.url + 'search/%s/0/7/200'  # order by seed       
-        self.re_title_url = '<td>.*?".*?/torrent/\d+/(?P<title>.*?)%s".*?<a href=".*?(?P<url>magnet.*?)%s".*?</td>'
+        self.re_title_url = '<td>.*?".*?/torrent/\d+/(?P<title>.*?)%s".*?<a href=".*?(?P<url>magnet.*?)%s".*?</td>\s*<td align="right">(?P<seeders>\d+)</td>'
  
     ###################################################################################################
     def isEnabled(self):
@@ -150,7 +150,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
     ###################################################################################################
     def _doSearch(self, search_params, show=None):
         results = []
-        searchURL = self.proxy._buildURL(self.searchurl %(urllib.quote(search_params)))    
+        searchURL = self.proxy._buildURL(self.searchurl % (urllib.quote(search_params)))
         logger.log(u"Search string: " + searchURL, logger.DEBUG)
                     
         data = self.getURL(searchURL)
@@ -160,7 +160,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
         re_title_url = self.proxy._buildRE(self.re_title_url)
         
         #Extracting torrent information from searchURL                   
-        match = re.compile(re_title_url, re.DOTALL ).finditer(urllib.unquote(data))
+        match = re.compile(re_title_url, re.DOTALL).finditer(urllib.unquote(data))
         for torrent in match:
             #Accept Torrent only from Good People
             if sickbeard.THEPIRATEBAY_TRUSTED and re.search('(VIP|Trusted|Helpers)',torrent.group(0))== None:
@@ -168,7 +168,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
                 continue
             
             #Do not know why but Sick Beard skip release with a '_' in name
-            item = (torrent.group('title').replace('_','.'),torrent.group('url'))
+            item = (torrent.group('title').replace('_', '.'), torrent.group('url'), torrent.group('seeders'))
             results.append(item)
         return results
 
@@ -249,11 +249,11 @@ class ThePirateBayCache(tvcache.TVCache):
                 
         for torrent in match:
             #accept torrent only from Trusted people
-            if sickbeard.THEPIRATEBAY_TRUSTED and re.search('(VIP|Trusted|Helpers)',torrent.group(0))== None:
+            if sickbeard.THEPIRATEBAY_TRUSTED and re.search('(VIP|Trusted|Helpers)', torrent.group(0))== None:
                 logger.log(u"ThePirateBay Provider found result "+torrent.group('title')+" but that doesn't seem like a trusted result so I'm ignoring it",logger.DEBUG)
                 continue
             
-            item = (torrent.group('title').replace('_','.'),torrent.group('url'))
+            item = (torrent.group('title').replace('_','.'), torrent.group('url'), torrent.group('seeders'))
             self._parseItem(item)
 
     ###################################################################################################

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -168,16 +168,16 @@ class ThePirateBayProvider(generic.TorrentProvider):
                 continue
             
             #Do not know why but Sick Beard skip release with a '_' in name
-            item = (torrent.group('title').replace('_', '.'), torrent.group('url'), torrent.group('seeders'))
+            item = (torrent.group('title').replace('_', '.'), torrent.group('url'), int(torrent.group('seeders')))
             results.append(item)
         return results
 
     ###################################################################################################
     def _get_title_and_url(self, item):
-        (title, url) = item
+        (title, url, seeders) = item
         if url:
             url = url.replace('&amp;','&')
-        return (title, url)
+        return (title, url, seeders)
 
     ###################################################################################################
     def getURL(self, url, headers=None):
@@ -265,7 +265,7 @@ class ThePirateBayCache(tvcache.TVCache):
 
     ###################################################################################################
     def _parseItem(self, item):
-        (title, url) = item
+        (title, url, seeders) = item
         if not title or not url:
             return
         logger.log(u"Adding item to cache: "+title, logger.DEBUG)

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -127,7 +127,7 @@ class TORRENTZProvider(generic.TorrentProvider):
             results = []
             for curItem in items:
                 try:
-                    (title, url) = self._get_title_and_url(curItem)
+                    (title, url, seeders) = self._get_title_and_url(curItem)
                     if not title or not url:
                         #logger.log(u"The XML returned from the " + self.name + " RSS feed is incomplete: %(title)s %(url)s" % {'title': title, 'url': url}, logger.ERROR)
                         continue
@@ -155,10 +155,17 @@ class TORRENTZProvider(generic.TorrentProvider):
     def _get_title_and_url(self, item):
         title = item.findtext('title')
         torrentz_url = item.findtext('guid')
-        url = self._getTorrentzCache(torrentz_url)
+        description = item.findtext('description')
 
+        seeders = 0
+
+        match = re.match('Size: (?P<size>.*?) Seeds: (?P<seeds>.*?) Peers: (?P<peers>\d+)', description, re.I)
+        if match:
+            seeders = int(match.groupdict()['seeds'].replace(',', ''))
+
+        url = self._getTorrentzCache(torrentz_url)
         
-        return (title, url)
+        return (title, url, seeders)
 
     def _extract_name_from_filename(self, filename):
         name_regex = '(.*?)\.?(\[.*]|\d+\.TPB)\.torrent$'

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -758,6 +758,7 @@ class ConfigSearch:
         # handle some special cases
         sickbeard.TORRENT_PAUSED = config.checkbox_to_value(postData.get("torrent_paused"))
         sickbeard.PREFER_EPISODE_RELEASES = config.checkbox_to_value(postData.get("prefer_episode_releases"))
+        sickbeard.MIN_SEEDERS = config.to_int(postData.get("minimum_seeders"), default=1)
         sickbeard.SAB_APIKEY = postData.get('sab_apikey', '').strip()
         sickbeard.TORRENT_RATIO = config.to_float(postData.get("torrent_ratio"), default=1.0)
 


### PR DESCRIPTION
This is my first contribution to Sick Beard so please let me know if I did something wrong or failed meet any PR guidelines. 

### Description
This enhancement adds a config option that will allow the user to set the minimum number of seeds a torrent is required to have before it is added to the download list. Right now I have implemented support for the TPB and Torrentz.eu providers, and I hope to add more soon.

The filtering option will not cause a crash if the provider does not support number of seeds, it will fail gracefully in the sense that it will not filter on this criteria if it is not supported.

#### Screenshot
![](http://i.imgur.com/b2jSubX.png)