### PR TITLE
Fixed crash in uTorrent ratio logging

### DIFF
--- a/sickbeard/downloaders/utorrent.py
+++ b/sickbeard/downloaders/utorrent.py
@@ -161,5 +161,5 @@ def sendTORRENT(torrent):
             
             params = {'token': auth, 'action': 'setprops', 'hash': torrent_hash, 's': 'seed_ratio', 'v': float(sickbeard.TORRENT_RATIO)*10}
             _sendRequest(session,params,None,"SetRatio(ratio)")
-            logger.log("[uTorrent] Ratio set to " + sickbeard.TORRENT_RATIO + " for torrent with hash " + torrent_hash,logger.DEBUG)
+            logger.log("[uTorrent] Ratio set to " + str(sickbeard.TORRENT_RATIO) + " for torrent with hash " + torrent_hash,logger.DEBUG)
         return True


### PR DESCRIPTION
I was getting "cannot concatenate string and float" when the logger was trying to output the results of passing to uTorrent, which was causing the whole check to fail before the call could return true. Casting the torrent ratio as a string seems to fix the problem.