### PR TITLE
fix nma api address

### DIFF
--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 
 __version__ = "0.1"
 
-API_SERVER = 'nma.usk.bz'
+API_SERVER = 'www.notifymyandroid.com'
 ADD_PATH   = '/publicapi/notify'
 
 USER_AGENT="PyNMA/v%s"%__version__


### PR DESCRIPTION
notifymyandroid notification is currently broken because the api server utilized in the code is no longer available. updated the api server to the working server.