### PR TITLE
Fix regression that broke IP binding to 0.0.0.0

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -352,13 +352,16 @@ def main():
 
     # sickbeard.WEB_HOST is available as a configuration value in various
     # places but is not configurable. It is supported here for historic reasons.
-    if sickbeard.WEB_HOST and sickbeard.WEB_HOST != '0.0.0.0':
+    if sickbeard.WEB_HOST:
         webhost = sickbeard.WEB_HOST
     else:
-        if sickbeard.WEB_IPV6:
+        webhost = '127.0.0.1'
+
+    if sickbeard.WEB_IPV6:
+        if webhost == '127.0.0.1':
+            webhost = '::1'
+        elif webhost == '0.0.0.0':
             webhost = '::'
-        else:
-            webhost = '127.0.0.1'
 
     if forcedHost:
         logger.log(u"Forcing web server to address " + str(forcedHost))


### PR DESCRIPTION
Commit https://github.com/junalmeida/Sick-Beard/commit/371d37928469e3615a12c84ce0258106bdf55a17 changed the default webhost to 127.0.0.1 for better Windows compatibility. The result of that commit is below:
https://github.com/junalmeida/Sick-Beard/blob/5d2b0ef3a9efb809e77831052abb168d06be7ab4/SickBeard.py#L355-L361

The above logic prevents setting the webhost to 0.0.0.0 when running in IPv4 mode. It also gives an inconsistent default webhost depending on whether IPv6 is enabled or not. This commit fixes the regression, and also makes the behavior consistent between IPv4 and IPv6.