### PR TITLE
Fix ThePirateBay and Speed.cd provider plugins

### DIFF
--- a/sickbeard/providers/speed.py
+++ b/sickbeard/providers/speed.py
@@ -185,11 +185,16 @@ class SpeedProvider(generic.TorrentProvider):
         logger.log("[" + self.name + "] Attempting to Login")
 
         try:
-            response = self.session.post(self.url + "takeElogin.php", data=login_params, timeout=30, verify=False)
+            response = self.session.post(self.url + "takelogin.php", data=login_params, timeout=30, verify=False)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
             self.session = None
             sys.tracebacklimit = 0    # raise exception to sickbeard but hide the stack trace.
             raise Exception("[" + self.name + "] " + self.funcName() + " Error: " + str(e))
+
+        if "No page exists at your destination address" in response.content:
+            self.session = None
+            sys.tracebacklimit = 0    # raise exception to sickbeard but hide the stack trace.
+            raise Exception("[" + self.name + "] Login attempt returned 404 page.")
 
         if "We could not recognize your account properly. Mind if we double check that? It's for your own security." in response.content:
             self.session = None

--- a/sickbeard/providers/speed.py
+++ b/sickbeard/providers/speed.py
@@ -142,7 +142,7 @@ class SpeedProvider(generic.TorrentProvider):
         data = self.getURL(searchUrl)
         results = []
         if data:
-            for torrent in re.compile("<td class=\"lft\"><div><a href=\"\/t\/.*?\" class=\"torrent\" id=\"(?P<id>.*?)\"><b>(?P<title>.*?)</b></a>", re.MULTILINE | re.DOTALL).finditer(data):
+            for torrent in re.compile('<td class=\"lft\" colspan=\"2\"><div><a href=\"\/t\/(?P<id>\d+)\"><b>(?P<title>.*?)<\/b><\/a>', re.MULTILINE | re.DOTALL).finditer(data):
                 item = (self.remove_tags.sub('', torrent.group('title')), self.url + "download.php?torrent=" + torrent.group('id'))
                 results.append(item)
             if len(results):

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -56,7 +56,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
         self.supportsBacklog = True
         self.cache = ThePirateBayCache(self)
         self.proxy = ThePirateBayWebproxy() 
-        self.url = 'http://thepiratebay.se/'
+        self.url = 'http://thepiratebay.org/'
         self.searchurl =  self.url + 'search/%s/0/7/200'  # order by seed       
         self.re_title_url = '<td>.*?".*?/torrent/\d+/(?P<title>.*?)%s".*?<a href=".*?(?P<url>magnet.*?)%s".*?</td>'
  


### PR DESCRIPTION
The ThePirateBay provider is using the old se address. Updated to use the org address.

Speed.cd login page has changed. Updated the URL and added an exception for "page not found" errors (speedcd doesnt return 404).  Also updated the regex used in search during backlog