### PR TITLE
Update thepiratebay scraper. Fixes cache and removes broken Proxy

### DIFF
--- a/data/interfaces/default/config_providers.tmpl
+++ b/data/interfaces/default/config_providers.tmpl
@@ -190,6 +190,7 @@
                     </div><!-- /tvtorrentsDiv //-->
                     
                 <div class="providerDiv" id="thepiratebayDiv">
+                        <!-- this is currently non-functional. none of the proxys appear to be online, and the provider doesnt implemnt them right now.
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="thepiratebay_proxy" id="thepiratebay_proxy" #if $sickbeard.THEPIRATEBAY_PROXY then "checked=\"checked\"" else ""#/>
                             <label class="clearfix" for="thepiratebay_proxy">
@@ -210,6 +211,7 @@
                                	</span>
                             </label>
                         </div>
+                        -->
                         
                         <div class="field-pair">
                             <input type="checkbox" class="enabler" name="thepiratebay_url_override_enable" id="thepiratebay_url_override_enable" #if $sickbeard.THEPIRATEBAY_URL_OVERRIDE then "checked=\"checked\"" else ""#/>


### PR DESCRIPTION
- Cleaned up the previous update to the search
- Only search for the api server and trackers once
- Fixed bug that caused traceback on name searches with commas
- Updates cache to scrape using new api method
- Removed proxies (they all appear to be broken and the new scrape doesnt take them into account)